### PR TITLE
Fix documentation layout in Firefox

### DIFF
--- a/source/stylesheets/modules/_app-pane.scss
+++ b/source/stylesheets/modules/_app-pane.scss
@@ -26,6 +26,7 @@
       .app-pane__body {
         display: flex;
         flex: 1 1 100%;
+        min-height: 0;
         
         > * {
           overflow-x: scroll;


### PR DESCRIPTION
The header is not appearing and neither the body nor the table of contents are scrollable in Firefox.

This fixes that by adding a min-height: 0; declaration to the `.app-pane__body` element. Apparently:

“Flex items establish a default minimum size that's based on their children's intrinsic size (which doesn't consider "overflow" properties on their children/descendants).”

“Whenever you've got an element with overflow: [hidden|scroll|auto] inside of a flex item, you need to give its ancestor flex item min-width:0 (in a horizontal flex container) or min-height:0 (in a vertical flex container), to disable this min-sizing behavior, or else the flex item will refuse to shrink smaller than the child's min-content size.” [1] [2]

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1043520
[2]: http://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox