### PR TITLE
Always show code block scrollbars (Webkit, Mac OS)

### DIFF
--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -11,6 +11,7 @@
 @import "govuk_frontend_toolkit/helpers";
 @import "govuk_frontend_toolkit/measurements";
 @import "govuk_frontend_toolkit/typography";
+@import "govuk_frontend_toolkit/with-scrollbars";
 
 @import "modules/app-pane";
 @import "modules/govuk-logo";

--- a/source/stylesheets/govuk_frontend_toolkit/_with-scrollbars.scss
+++ b/source/stylesheets/govuk_frontend_toolkit/_with-scrollbars.scss
@@ -1,0 +1,26 @@
+@mixin with-scrollbars {
+  &::-webkit-scrollbar {
+    height: 8px;
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    -webkit-border-radius:5px;
+    border-radius:5px;
+    background:rgba(0,0,0,0.1);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    -webkit-border-radius:5px;
+    border-radius:5px;
+    background:rgba(0,0,0,0.2);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background:rgba(0,0,0,0.4);
+  }
+
+  &::-webkit-scrollbar-thumb:window-inactive {
+    background:rgba(0,0,0,0.05);
+  }
+}

--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -42,6 +42,7 @@
     padding: 15px;
     overflow: auto;
     position: relative;
+    @include with-scrollbars;
   }
 
   code {


### PR DESCRIPTION
Unfortunately on Mac and iOS devices scrollbars are not by default visible until you scroll the container. This means it’s not always obvious when a container can be scrolled, as is the case with some code examples in the documentation.

There is a work around for this but it essentially involves re-styling the scrollbars. [1] [2] [3] This PR does just that, attempting to make them look as close to native Mac OS controls as possible.

[1]: http://stackoverflow.com/a/7855592
[2]: https://davidwalsh.name/osx-overflow
[3]: http://blog.0100.tv/2012/11/webkit-scrollbars-on-os-x/