### PR TITLE
Add "link" icon to headings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,13 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem 'middleman', '>= 4.0.0'
 gem 'middleman-livereload'
 gem 'middleman-compass', '>= 4.0.0'
-gem 'middleman-sprockets', '~> 4.0.0' 
+gem 'middleman-sprockets', '~> 4.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
+
+gem 'govuk-lint'
+
+group :test do
+  gem 'rspec'
+  gem 'rspec-html-matchers'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    ast (2.3.0)
     backports (3.6.8)
     chunky_png (1.3.7)
     coffee-script (2.4.1)
@@ -28,6 +29,7 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.2)
     contracts (0.13.0)
+    diff-lcs (1.2.5)
     dotenv (2.1.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -39,6 +41,9 @@ GEM
     fastimage (2.0.0)
       addressable (~> 2)
     ffi (1.9.14)
+    govuk-lint (1.2.1)
+      rubocop (~> 0.39.0)
+      scss_lint
     haml (4.0.7)
       tilt
     hamster (3.0.0)
@@ -95,8 +100,11 @@ GEM
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
+    mini_portile2 (2.1.0)
     minitest (5.9.1)
     multi_json (1.12.1)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     padrino-helpers (0.13.3.2)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.2)
@@ -104,14 +112,45 @@ GEM
     padrino-support (0.13.3.2)
       activesupport (>= 3.1)
     parallel (1.9.0)
+    parser (2.3.2.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     rack (1.6.4)
     rack-livereload (0.3.16)
       rack
+    rainbow (2.1.0)
+    rake (11.3.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-html-matchers (0.8.1)
+      nokogiri (~> 1)
+      rspec (>= 3.0.0.a, < 4)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     sass (3.4.22)
+    scss_lint (0.50.3)
+      rake (>= 0.9, < 12)
+      sass (~> 3.4.20)
     servolux (0.12.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -123,18 +162,22 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  govuk-lint
   middleman (>= 4.0.0)
   middleman-compass (>= 4.0.0)
   middleman-livereload
   middleman-sprockets (~> 4.0.0)
   redcarpet (~> 3.3.2)
+  rspec
+  rspec-html-matchers
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.12.0
+   1.12.1

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+require 'lib/custom_html_renderer'
+
 ###
 # Page options, layouts, aliases and proxies
 ###
@@ -5,8 +7,7 @@
 set :markdown_engine, :redcarpet
 set :markdown,
   fenced_code_blocks: true,
-  smartypants: true,
-  with_toc_data: true
+  renderer: CustomHTMLRenderer
 
 # Per-page layout changes:
 #

--- a/lib/custom_html_renderer.rb
+++ b/lib/custom_html_renderer.rb
@@ -1,0 +1,27 @@
+require 'middleman-core/renderers/redcarpet'
+
+class CustomHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
+  include Redcarpet::Render::SmartyPants
+
+  # This is effectively a reimplementation of
+  # https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/html.c#L307-L325
+  # in Ruby.
+  def header(text, level)
+    fragment = header_anchor(text)
+    <<~EOS
+      <h#{level} id="#{fragment}" class="anchored-heading">
+        <a href="##{fragment}" class="anchored-heading__icon" aria-hidden="true">🔗</a>
+        #{text}
+      </h#{level}>
+    EOS
+  end
+
+private
+
+  def header_anchor(text)
+    text
+      .gsub(/\<.*?\>/, '')
+      .gsub(/\&.*?\;/, '')
+      .parameterize
+  end
+end

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -12,6 +12,7 @@
 @import "govuk_frontend_toolkit/measurements";
 @import "govuk_frontend_toolkit/typography";
 
+@import "modules/anchored-header";
 @import "modules/app-pane";
 @import "modules/govuk-logo";
 @import "modules/header";

--- a/source/stylesheets/modules/_anchored-header.scss
+++ b/source/stylesheets/modules/_anchored-header.scss
@@ -1,0 +1,14 @@
+.anchored-heading {
+  position: relative;
+}
+
+.anchored-heading__icon {
+  position: absolute;
+  display: none;
+  text-decoration: none;
+  left: -1em;
+}
+
+.anchored-heading:hover .anchored-heading__icon {
+  display: block;
+}

--- a/spec/custom_html_renderer_spec.rb
+++ b/spec/custom_html_renderer_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require_relative '../lib/custom_html_renderer'
+
+RSpec.describe CustomHTMLRenderer do
+  describe '#header' do
+    let(:header) { subject.header('bananas', 1) }
+    let(:header_with_inline_html) { subject.header('<code>hello</code> world', 1) }
+    let(:header_with_html_entiites) { subject.header('apples &amp; pears', 1) }
+
+    it 'includes a heading tag with an anchor-heading class' do
+      expect(header).to have_tag('h1.anchored-heading')
+    end
+
+    it 'includes an anchor tag' do
+      expect(header).to have_tag('a.anchored-heading__icon')
+    end
+
+    # The following tests exist to match Redcarpet's default anchor fragment
+    # generation logic, which you can see here:
+    # https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/html.c#L274
+    context 'given text with inline HTML' do
+      it 'removes inline HTML from the anchor fragment' do
+        expect(header_with_inline_html).to include('#hello-world')
+      end
+    end
+
+    context 'given text with HTML entities' do
+      it 'removes HTML entities from the anchor fragment' do
+        expect(header_with_html_entiites).to include('#apples-pears')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'rspec'
+require 'rspec-html-matchers'
+require 'middleman'
+
+RSpec.configure do |config|
+  config.include RSpecHtmlMatchers
+end


### PR DESCRIPTION
There's a desire for developers to be able to easily get a "deep link"
into a specific heading in the tech documentation. This implements a
GitHub-esque link icon which appears when hovering over a heading.

This has proven a bit of a faff – our headings are outputted by a
markdown parser (Redcarpet) which means we have to create a custom
Redcarpet renderer (which extends from the Middleman default, which
extends from Redcarpet::Renderer::HTML) and override the `header`
method.

This introduces further complexity, as Redcarpet builds its URL
fragments in a native extension (see
https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/html.c#L274)
which can't be called from Ruby – only the `header` method is exposed.
Subsequently, there's a `header_anchor` method in the class which is
analogous to the Redcarpet implementation.

On the whole, I'm not 100% happy with this approach – it feels like we're
altering Redcarpet a bit too much for my liking.

The link icon in use is currently a Unicode link character (🔗) – this
will be updated once there's consensus on which icon we should actually
be using.