### PR TITLE
Add Jasmine for JS testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,10 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem 'middleman', '>= 4.0.0'
 gem 'middleman-livereload'
 gem 'middleman-compass', '>= 4.0.0'
-gem 'middleman-sprockets', '~> 4.0.0' 
+gem 'middleman-sprockets', '~> 4.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
+
+group :development, :test do
+  gem 'jasmine'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,12 @@ GEM
     hashie (3.4.6)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
+    jasmine (2.5.1)
+      jasmine-core (>= 2.5.1, < 3.0.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.5.2)
     json (1.8.3)
     kramdown (1.12.0)
     listen (3.0.8)
@@ -104,9 +110,11 @@ GEM
     padrino-support (0.13.3.2)
       activesupport (>= 3.1)
     parallel (1.9.0)
+    phantomjs (2.1.1.0)
     rack (1.6.4)
     rack-livereload (0.3.16)
       rack
+    rake (11.3.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -128,6 +136,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  jasmine
   middleman (>= 4.0.0)
   middleman-compass (>= 4.0.0)
   middleman-livereload
@@ -137,4 +146,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.12.0
+   1.12.1

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ This will create a `build` subfolder in the application folder which contains th
 ## Publish
 
 Once built, the simplest way to host the website is to copy the contents of the build folder to some hosting via FTP.
+
+## Tests
+
+We have some automated JavaScript tests that use [Jasmine](https://jasmine.github.io/) as a test framework. If you're only making changes to content, you shouldn't need to touch these, but it's worth running them when making any changes that might alter JS behaviour.
+
+To run the tests on your machine:
+
+- Run `bundle exec rake jasmine`
+- Navigate to `http://localhost:8888` in a browser of your choosing
+- Peruse the output of your tests

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'jasmine'
+load 'jasmine/tasks/jasmine.rake'

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,134 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - source/javascripts/**/*.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - source/stylesheets/**/*.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# random
+#
+# Run specs in semi-random order.
+# Default: false
+#
+# EXAMPLE:
+#
+# random: true
+#
+random:


### PR DESCRIPTION
We're keen to do some testing of the JavaScript bits and bobs in this
project, and subsequently need a test framework to do so. Jasmine
appears to be the weapon of choice in other parts of GDS (including the
service manual), so it makes sense to use it here, too.

This adds a very basic Jasmine configuration that we can write some
tests on top of.