### PR TITLE
Add deployment script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # Ignore .DS_store file
 .DS_Store
+
+Staticfile.auth

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+error() {
+  echo " ! $1"
+}
+
+# Check that we have a Staticfile.auth we can use
+echo "Checking Staticfile.auth..."
+if [[ ! -f Staticfile.auth ]]; then
+  error "You are attempting to deploy to an environment that requires a Staticfile.auth, but do not have one locally."
+  error "Please add a Staticfile.auth file to this directory and try again."
+  error
+  error "For information on generating a Staticfile.auth, see"
+  error "http://docs.cloudfoundry.org/buildpacks/staticfile/index.html#basic-auth"
+  exit 1
+fi
+echo "OK!"
+
+# Check that we're on master, or there's an environment variable set to override
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "Checking branch..."
+if [[ $BRANCH != "master" ]] && [[ $I_REALISE_I_AM_NOT_ON_MASTER != "y" ]]; then
+  error "Current branch is not master, cowardly refusing to deploy"
+  error "To force override, run this again with I_REALISE_I_AM_NOT_ON_MASTER=y"
+  exit 1
+fi
+echo "OK!"
+
+# Check that we've not got any uncommitted files in our working directory
+echo "Checking dirty working tree..."
+DIRTY_WORKING_TREE=$(git status --porcelain 2>/dev/null | egrep "^(M| M)")
+if [[ $DIRTY_WORKING_TREE != "" ]]; then
+  error "There are uncommitted changes in the working directory."
+  error "Please commit or stash all changes and try again."
+  exit 1
+fi
+echo "OK!"
+
+# Check if we're behind our Git remote
+echo "Checking if we're behind origin..."
+BEHIND_ORIGIN=$(git fetch origin >/dev/null 2>&1; git diff --stat HEAD...@{u})
+if [[ $BEHIND_ORIGIN != "" ]]; then
+  error "You are behind the origin branch - please pull and try again."
+  exit 1
+fi
+echo "OK!"
+
+bundle exec middleman build
+cp Staticfile.auth build
+cf target -s integration
+cf push paas-tech-docs-integration -b staticfile_buildpack -m 64M -p ./build


### PR DESCRIPTION
This adds an extremely basic script at `script/deploy` that pushes the
site to integration on PaaS, along with a few pre-flight checks:

- It ensures we have a Staticfile.auth file present, which is required
  to give us basic authentication on PaaS
- Checks we're on master
- Checks our working tree isn't dirty (in English: checks we have no
  files that aren't commited into git that would be built)
- Checks that our branch is up-to-date