### PR TITLE
Add custom nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,75 @@
+# This configuration is based from the CloudFoundry static buildpack's default, which you can view here:
+# https://github.com/cloudfoundry/staticfile-buildpack/blob/bd7a288e11b27f1c5095d62bcd09780a14c5151e/conf/nginx.conf
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  default_type application/octet-stream;
+  include mime.types;
+  sendfile on;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gunzip on;
+  gzip_static always;
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+  gzip_vary on;
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_pushstate")) %>
+      if (!-e $request_filename) {
+        rewrite ^(.*)$ / break;
+      }
+      <% end %>
+      index index.html index.htm Default.htm;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
+        autoindex on;
+      <% end %>
+      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
+        auth_basic "Restricted";                                #For Basic Auth
+        auth_basic_user_file <%= auth_file %>;  #For Basic Auth
+      <% end %>
+      <% if ENV["FORCE_HTTPS"] %>
+        if ($http_x_forwarded_proto != "https") {
+          return 301 https://$host$request_uri;
+        }
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
+        ssi on;
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
+        add_header Strict-Transport-Security "max-age=31536000";
+      <% end %>
+      if ($host != "paas-tech-docs-integration.cloudapps.digital") {
+        return 301 https://paas-tech-docs-integration.cloudapps.digital$request_uri;
+      }
+    }
+
+  <% unless File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_dotfiles")) %>
+    location ~ /\. {
+      deny all;
+      return 404;
+    }
+  <% end %>
+  }
+}

--- a/script/deploy
+++ b/script/deploy
@@ -50,5 +50,6 @@ echo "OK!"
 
 bundle exec middleman build
 cp Staticfile.auth build
+cp nginx.conf build
 cf target -o govuk-service-manual -s integration
 cf push


### PR DESCRIPTION
This adds a custom nginx configuration, which is based on the [CloudFoundry static buildpack's default one](https://github.com/cloudfoundry/staticfile-buildpack/blob/bd7a288e11b27f1c5095d62bcd09780a14c5151e/conf/nginx.conf), which forces a 301 redirect to the "canonical" URL of the website if the supplied Host header is anything over than paas-tech-docs-integration.cloudapps.digital.