### PR TITLE
Add a max-width to images

### DIFF
--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -14,6 +14,10 @@
     padding-top: $gutter-half;
   }
 
+  img {
+    max-width: 100%;
+  }
+
   ol, ul {
     padding-left: $gutter-half;
 

--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -16,6 +16,8 @@
 
   img {
     max-width: 100%;
+    width: auto;
+    height: auto;
   }
 
   ol, ul {


### PR DESCRIPTION
At the moment, an image inserted into the tech docs will be rendered at
whatever resolution it's supplied in. This is somewhat far from ideal,
as a massive image could end up breaking the page in unpleasant ways.

This adds a max-width of 100% to all images inside the technical
documentation container to ensure we stop anything overflowing it.

Before:
![screen shot 2016-12-02 at 14 58 19](https://cloud.githubusercontent.com/assets/1315466/20838361/1bbe4306-b8a0-11e6-88da-5a3d9e5c219a.png)

After:
![screen shot 2016-12-02 at 14 58 37](https://cloud.githubusercontent.com/assets/1315466/20838367/1ffff766-b8a0-11e6-8235-ef621afb3abb.png)

