### PR TITLE
Automatically linkify images

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+require 'lib/tech_docs_html_renderer'
+
 ###
 # Page options, layouts, aliases and proxies
 ###
@@ -6,7 +8,8 @@ set :markdown_engine, :redcarpet
 set :markdown,
   fenced_code_blocks: true,
   smartypants: true,
-  with_toc_data: true
+  with_toc_data: true,
+  renderer: TechDocsHTMLRenderer
 
 # Per-page layout changes:
 #

--- a/lib/tech_docs_html_renderer.rb
+++ b/lib/tech_docs_html_renderer.rb
@@ -1,0 +1,7 @@
+require 'middleman-core/renderers/redcarpet'
+
+class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
+  def image(link, *args)
+    %(<a href="#{link}" target="_blank">#{super}</a>)
+  end
+end


### PR DESCRIPTION
It might be nice for us to automatically wrap images in a link, so if
they're shrunk for whatever reason they can be clicked on to show a
full-resolution version. This does just that.

There's not an option built in to Redcarpet which allows us to do this,
so this adds a custom Redcarpet renderer which wraps up images in an <a>
tag.