### PR TITLE
Add CloudFoundry manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: paas-tech-docs-integration
+  memory: 64M
+  path: ./build
+  buildpack: staticfile_buildpack

--- a/script/deploy
+++ b/script/deploy
@@ -50,5 +50,5 @@ echo "OK!"
 
 bundle exec middleman build
 cp Staticfile.auth build
-cf target -s integration
-cf push paas-tech-docs-integration -b staticfile_buildpack -m 64M -p ./build
+cf target -o govuk-service-manual -s integration
+cf push


### PR DESCRIPTION
It seems advisable to supply a manifest.yml file to be used by
CloudFoundry rather than passing parameters into `cf push` – this way,
if someone runs the push command without running `script/deploy`, things
won't explode in a surprising fashion.

More info:
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html