### PR TITLE
Fix layout in IE8 through IE10

### DIFF
--- a/source/stylesheets/modules/_app-pane.scss
+++ b/source/stylesheets/modules/_app-pane.scss
@@ -1,5 +1,7 @@
 @include screen {
   @include media(tablet) {
+    $toc-width: 330px;
+
     .flexbox {
 
       body {
@@ -37,12 +39,23 @@
 
       .app-pane__toc {
         flex: 0 0 auto;
-        width: 330px;
+        width: $toc-width;
         border-right: 1px solid $grey-2;
       }
 
       .app-pane__content {
         flex: 1 1 auto;
+      }
+    }
+
+    .no-flexbox {
+      .app-pane__toc {
+        float: left;
+        width: $toc-width;
+      }
+
+      .app-pane__content {
+        margin-left: $toc-width;
       }
     }
   }


### PR DESCRIPTION
IE8 through IE10 don’t support flexbox, so fall back to a simpler layout with the navigation floated to the left.

We discussed moving away from flexbox to just using absolutely positioned divs to define the application layout, but it would require us to ‘know’ and fix the the size of the header. Given the header currently ‘breaks’ onto two lines for the Platform as a Service documentation, this won’t really work for us.

We are making an assumption that IE8-IE10 will account for a even lower percentage of users than we see on GOV.UK (~2.75%) as they will be from a more technical background. We should validate this once we have collected analytics data in production.

<img width="1301" alt="screen shot 2016-12-05 at 14 29 58" src="https://cloud.githubusercontent.com/assets/121939/20888560/68ab476e-baf7-11e6-8ed2-bc303919c268.png">
<img width="1303" alt="screen shot 2016-12-05 at 14 30 13" src="https://cloud.githubusercontent.com/assets/121939/20888561/68abe782-baf7-11e6-9002-f5030a06edad.png">
