### PR TITLE
Add canonical link tag

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -54,3 +54,10 @@ configure :build do
   # Minify Javascript on build
   # activate :minify_javascript
 end
+
+###
+# Tech Docs-specific configuration
+###
+
+# Host to use for canonical URL generation (without trailing slash)
+config[:host] = 'https://paas-tech-docs-integration.cloudapps.digital'

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -11,6 +11,8 @@
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
     <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
 
+    <link rel="canonical" href="<%= config[:host] %><%= current_page.url %>">
+
     <%= stylesheet_link_tag :print, media: 'print' %>
 
     <%= javascript_include_tag :application %>
@@ -148,7 +150,7 @@
                         <li><a href="#application-quota-sizing">Application quota sizing</a></li>
                       </ul>
                     </li>
-                    
+
                     <li>
                       <a href="#logging">Logging</a>
                       <ul>
@@ -173,6 +175,6 @@
       </div>
     </div>
 
-    
+
   </body>
 </html>


### PR DESCRIPTION
This adds a <link rel="canonical" /> tag to the <head> of the document
for SEO purposes, and a config option (`host`) to allow the canonical
host to be set.