### PR TITLE
Add some basic configuration options

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -59,17 +59,5 @@ end
 # Tech Docs-specific configuration
 ###
 
-# Host to use for canonical URL generation (without trailing slash)
-config[:host] = 'https://paas-tech-docs-integration.cloudapps.digital'
-
-config[:tech_docs] = {
-  show_govuk_logo: true,
-  service_name: 'Platform as a Service',
-  phase: 'Beta',
-  header_links: {
-    'About' => 'https://www.cloud.service.gov.uk',
-    'Get Started' => 'https://www.cloud.service.gov.uk/get-started',
-    'Documentation' => '/',
-    'Support' => 'https://www.cloud.service.gov.uk/support'
-  }
-}
+config[:tech_docs] = YAML.load_file('config/tech-docs.yml')
+                         .with_indifferent_access

--- a/config.rb
+++ b/config.rb
@@ -61,3 +61,15 @@ end
 
 # Host to use for canonical URL generation (without trailing slash)
 config[:host] = 'https://paas-tech-docs-integration.cloudapps.digital'
+
+config[:tech_docs] = {
+  show_govuk_logo: true,
+  service_name: 'Platform as a Service',
+  phase: 'Beta',
+  header_links: {
+    'About' => 'https://www.cloud.service.gov.uk',
+    'Get Started' => 'https://www.cloud.service.gov.uk/get-started',
+    'Documentation' => '/',
+    'Support' => 'https://www.cloud.service.gov.uk/support'
+  }
+}

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,0 +1,14 @@
+# Host to use for canonical URL generation (without trailing slash)
+host: https://docs.cloud.service.gov.uk
+
+# Header-related options
+show_govuk_logo: true
+service_name: Platform as a Service
+phase: Beta
+
+# Links to show on right-hand-side of header
+header_links:
+  About: https://www.cloud.service.gov.uk
+  Get Started: https://www.cloud.service.gov.uk/get-started
+  Documentation: /
+  Support: https://www.cloud.service.gov.uk/support

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -27,12 +27,17 @@
           <div class="header__container">
             <div class="header__brand">
               <a href="/">
-                <span class="govuk-logo">
-                  <img class="govuk-logo__printable-crown" src="/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
-                  GOV.UK
-                </span>
+                <% if config[:tech_docs][:show_govuk_logo] %>
+                  <span class="govuk-logo">
+                    <img class="govuk-logo__printable-crown" src="/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
+                    GOV.UK
+                  </span>
+                <% end %>
                 <span class="header__title">
-                  Platform as a Service <span class="phase-banner">Beta</span>
+                  <%= config[:tech_docs][:service_name] %>
+                  <% if config[:tech_docs][:phase] %>
+                    <span class="phase-banner"><%= config[:tech_docs][:phase] %></span>
+                  <% end %>
                 </span>
               </a>
             </div>
@@ -42,13 +47,18 @@
               Menu
             </label>
 
+            <% if config[:tech_docs][:header_links] %>
             <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation">
-              <ul>
-                <li><a href="#about">About</a></li>
-                <li><a href="#getstarted">Get started</a></li>
-                <li class="active"><a href="#documentation">Documentation</a></li>
-                <li><a href="#feedback">Feedback</a></li>
-              </ul>
+                <ul>
+                  <% config[:tech_docs][:header_links].each do |title, url| %>
+                    <li<% if url == current_page.url %> class="active"<% end %>>
+                      <a href="<%= url %>">
+                        <%= title %>
+                      </a>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
             </nav>
           </div>
         </header>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -11,7 +11,7 @@
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
     <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
 
-    <link rel="canonical" href="<%= config[:host] %><%= current_page.url %>">
+    <link rel="canonical" href="<%= config[:tech_docs][:host] %><%= current_page.url %>">
 
     <%= stylesheet_link_tag :print, media: 'print' %>
 
@@ -48,7 +48,7 @@
             </label>
 
             <% if config[:tech_docs][:header_links] %>
-            <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation">
+              <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation">
                 <ul>
                   <% config[:tech_docs][:header_links].each do |title, url| %>
                     <li<% if url == current_page.url %> class="active"<% end %>>
@@ -58,8 +58,8 @@
                     </li>
                   <% end %>
                 </ul>
-              <% end %>
-            </nav>
+              </nav>
+            <% end %>
           </div>
         </header>
       </div>


### PR DESCRIPTION
In an attempt to make the 'templatization' of this project a bit easier,
this adds a configuration hash in `config.rb` to set some options that
are likely to change between projects.

I'm not entirely convinced by the header links being in here – it does
nicely abstract them away from the actual HTML, but open to better
alternatives.