### PR TITLE
Fix custom renderer

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,10 +6,10 @@ require 'lib/tech_docs_html_renderer'
 
 set :markdown_engine, :redcarpet
 set :markdown,
-  fenced_code_blocks: true,
-  smartypants: true,
-  with_toc_data: true,
-  renderer: TechDocsHTMLRenderer
+    renderer: TechDocsHTMLRenderer.new(
+      fenced_code_blocks: true,
+      with_toc_data: true
+    )
 
 # Per-page layout changes:
 #

--- a/lib/tech_docs_html_renderer.rb
+++ b/lib/tech_docs_html_renderer.rb
@@ -1,6 +1,8 @@
 require 'middleman-core/renderers/redcarpet'
 
 class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
+  include Redcarpet::Render::SmartyPants
+
   def image(link, *args)
     %(<a href="#{link}" target="_blank">#{super}</a>)
   end


### PR DESCRIPTION
When passing a `renderer` argument to `set :markdown`, Middleman bins
all the other options you pass into it.

This isn't particularly helpful, so this sets the options in the custom
renderer class instead.