### PR TITLE
Fix fenced code blocks

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,9 +7,9 @@ require 'lib/tech_docs_html_renderer'
 set :markdown_engine, :redcarpet
 set :markdown,
     renderer: TechDocsHTMLRenderer.new(
-      fenced_code_blocks: true,
       with_toc_data: true
-    )
+    ),
+    fenced_code_blocks: true
 
 # Per-page layout changes:
 #


### PR DESCRIPTION
These are not related to rendering, and therefore should not be passed
into the markdown renderer, but the markdown parser.