### PR TITLE
Fix duplicated use of ‘#toc’ id, move classes to nav

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -64,8 +64,8 @@
         <div class="app-pane__toc">
           <div class="toc" data-module="table-of-contents">
             <a href="#" class="toc__close js-toc-close">Close</a>
-            <nav class="toc__list" id="toc" aria-labelledby="toc-heading">
-              <ul id="toc" class="js-toc-list">
+            <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
+              <ul>
                 <li>
                   <a href="#deploying-apps">Deploying apps</a>
                   <ul>


### PR DESCRIPTION
In an ideal world the `<ul>` can be simply generated by the table of contents helper, and this means we don’t want to e.g. add classes to it.

Those classes would be just as happy living on the parent `<nav>` element, and this also fixes the fact that two elements have the `#toc` id. Whoops.