### PR TITLE
Syntax Highlighting for Code Blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'middleman-livereload'
 gem 'middleman-compass', '>= 4.0.0'
 gem 'middleman-sprockets', '~> 4.0.0'
 gem 'middleman-autoprefixer', '~> 2.7.0'
+gem 'middleman-syntax', '~> 3.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,9 @@ GEM
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
+    middleman-syntax (3.0.0)
+      middleman-core (>= 3.2)
+      rouge (~> 2.0)
     minitest (5.9.1)
     multi_json (1.12.1)
     padrino-helpers (0.13.3.2)
@@ -124,6 +127,7 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
+    rouge (2.0.7)
     sass (3.4.22)
     servolux (0.12.0)
     sprockets (3.7.0)
@@ -147,6 +151,7 @@ DEPENDENCIES
   middleman-compass (>= 4.0.0)
   middleman-livereload
   middleman-sprockets (~> 4.0.0)
+  middleman-syntax (~> 3.0.0)
   redcarpet (~> 3.3.2)
   tzinfo-data
   wdm (~> 0.1.0)

--- a/config.rb
+++ b/config.rb
@@ -32,8 +32,9 @@ configure :development do
   activate :livereload
 end
 
-activate :sprockets
 activate :autoprefixer
+activate :sprockets
+activate :syntax
 
 ###
 # Helpers

--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -84,7 +84,7 @@ If you are just getting started learning CloudFoundry, you can use the sandbox s
 
 9. Create a `manifest.yml` file in the root of your local folder.
 
-    ```
+    ```yaml
     ---
     applications:
     - name: my-app

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -8,58 +8,58 @@ These instructions assume you have already carried out the setup process explain
 
 This is the code for the example app we are going to use. It is a basic web server that responds with a 'Hello World' message.
 
-  ```
-    const http = require('http');
+```js
+const http = require('http');
 
-    const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3000;
 
-    const server = http.createServer((req, res) => {
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'text/plain');
-      res.end('Hello World\n');
-    });
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello World\n');
+});
 
-    server.listen(port, () => {
-      console.log(`Server running on ${port}/`);
-    });
-  ```
+server.listen(port, () => {
+  console.log("Server running on ${port}");
+});
+```
 
 1. Save the code to a new local directory as ``example.js``.
 
 1. Add this ``manifest.yml`` file to the same directory:
       
-    ```
-    ---
-    applications:
-    - name: my-node-app
-      command: node example.js
-      memory: 256M
-      buildpack: nodejs_buildpack
-    ```
+  ```yaml
+  ---
+  applications:
+  - name: my-node-app
+    command: node example.js
+    memory: 256M
+    buildpack: nodejs_buildpack
+  ```
 
-    Replace ``my-node-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
+  Replace ``my-node-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 
-    The `memory` line tells the PaaS how much memory to allocate to the app.
+  The `memory` line tells the PaaS how much memory to allocate to the app.
 
-    A buildpack provides any framework and runtime support required by an app. In this case, because the app is written in Node.js, you use the ``nodejs_buildpack``.
+  A buildpack provides any framework and runtime support required by an app. In this case, because the app is written in Node.js, you use the ``nodejs_buildpack``.
 
-3. Include an npm ``package.json`` file to specify dependencies. The file should also specify a `start` command used to launch the app.
+1. Include an npm ``package.json`` file to specify dependencies. The file should also specify a `start` command used to launch the app.
   
-    This is a ``package.json`` file for our example app:
+  This is a ``package.json`` file for our example app:
 
-      ```
-            {
-              "name": "example",
-              "version": "0.0.1",
-              "author": "Demo",
-              "engines": {
-                "node": "6.1.0",
-                "npm": "2.7.4"
-              }
-            }
-      ```
+  ```json
+  {
+    "name": "example",
+    "version": "0.0.1",
+    "author": "Demo",
+    "engines": {
+      "node": "6.1.0",
+      "npm": "2.7.4"
+    }
+  }
+  ```
 
-    The ``"engines"`` values specify the versions of Node.js and npm that the PaaS should use to run your app. Note that older versions may not be available: if your version is not supported, you will see an error message when you try to upload and start the app.
+  The ``engines`` values specify the versions of Node.js and npm that the PaaS should use to run your app. Note that older versions may not be available: if your version is not supported, you will see an error message when you try to upload and start the app.
 
 1. You can optionally run `npm install` to preinstall dependencies rather than having them added during the PaaS staging process.
 
@@ -81,38 +81,39 @@ You can use the [cfenv](https://www.npmjs.com/package/cfenv) module to assist wi
 In your ``package.json`` file, you would specify ``cfenv`` as a dependency:
 
 ```json
-          {
-            //...
-            "dependencies": 
-            {
-              "cfenv": "*"
-            }
-          }
+{
+  //...
+  "dependencies": 
+  {
+    "cfenv": "*"
+  }
+}
 ```
 
 Then in your app, you can easily get configuration information for backing services. This is an example of how to connect to a PostgreSQL service.
 
-  ```
-        var cfenv = require("cfenv");
-        var pg = require('pg');
-        var appEnv = cfenv.getAppEnv();
-        var connectionString = appEnv.getServiceURL(/.*/);
-        var client = new pg.Client(connectionString);
-        client.ssl = true;
-        client.connect();
-  ```
+```js
+var cfenv = require("cfenv");
+var pg = require('pg');
+var appEnv = cfenv.getAppEnv();
+var connectionString = appEnv.getServiceURL(/.*/);
+var client = new pg.Client(connectionString);
+
+client.ssl = true;
+client.connect();
+```
 
 Note that in the above you should replace "my-postgres" with the exact name of the PostgreSQL service you created. The ``getServiceURL`` function returns a connection string which includes the username and password required to connect to the database.
 
 You should also remember to include dependencies for any service bindings in ``package.json``.
 
 ```json
-        {
-          //...
-          "dependencies": 
-          {
-            "pg": "*"
-          }
-        }
+{
+  //...
+  "dependencies": 
+  {
+    "pg": "*"
+  }
+}
 ```
 

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -15,7 +15,7 @@ Note that the only database service currently supported by PaaS is PostgreSQL. I
 
 1. Create a manifest.yml file in the folder where you checked out your app.
 
-    ```
+    ```yaml
     ---
     applications:
     - name: my-rails-app

--- a/source/documentation/deploying_apps/deploying_static_sites.md
+++ b/source/documentation/deploying_apps/deploying_static_sites.md
@@ -17,7 +17,7 @@ These steps assume you have already carried out the setup process explained in t
 
 2. Add some markup to the `index.html` file:
 
-    ``` 
+    ```html
     <html>
       <head>
         <title>Static Site</title>
@@ -31,7 +31,7 @@ These steps assume you have already carried out the setup process explained in t
 3. Create a `manifest.yml` file in the same directory. The manifest file tells 
    Cloud Foundry what to do with your app.
 
-    ```
+    ```yaml
     ---
     applications:
     - name: my-static-site

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -1,5 +1,3 @@
-<br><br>
-
 Government PaaS is a cloud-hosting platform being built by the Government Digital Service (GDS). PaaS manages the deployment of your apps, services and background tasks so you don’t need to hire specialist cloud skills to do so.
 
 <aside class="notice">

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,6 +2,7 @@
 title: GOV.UK PaaS
 ---
 
+<%= partial 'documentation/index' %>
 <%= partial 'documentation/deploying_apps/index' %>
 <%= partial 'documentation/deploying_apps/excluding_files' %>
 <%= partial 'documentation/deploying_apps/env_variables' %>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -12,6 +12,9 @@
 @import "govuk_frontend_toolkit/measurements";
 @import "govuk_frontend_toolkit/typography";
 
+@import "palette/syntax-highlighting";
+@import "syntax-highlighting";
+
 @import "modules/anchored-heading";
 @import "modules/app-pane";
 @import "modules/govuk-logo";

--- a/source/stylesheets/_syntax-highlighting.scss
+++ b/source/stylesheets/_syntax-highlighting.scss
@@ -83,7 +83,7 @@
   
   .nt,      /* Name.Tag */  
   .nx {     /* Name.Other */
-    color: $code-0D;
+    color: $code-09;
   }
 
   .ne {     /* Name.Exception */

--- a/source/stylesheets/_syntax-highlighting.scss
+++ b/source/stylesheets/_syntax-highlighting.scss
@@ -1,0 +1,196 @@
+.highlight {
+
+  /* Map Rouge / Pygments Tokens to work with 'Base 16' themes */
+
+  background: $code-00;
+  color: $code-05;
+
+  /**
+   * Comments
+   */
+  
+  .c,       /* Comment */
+  .cm,      /* Comment.Multiline */
+  .cp,      /* Comment.Preproc */
+  .c1,      /* Comment.Single */
+  .cs {     /* Comment.Special */
+    color: $code-03;
+  }
+  
+  /**
+   * Keywords
+   */
+
+  .k,       /* Keyword */
+  .kc,      /* Keyword.Constant */
+  .kd,      /* Keyword.Declaration */
+  .kp,      /* Keyword.Pseudo */
+  .kr {     /* Keyword.Reserved */
+    color: $code-0E;
+  }
+
+  .kn {     /* Keyword.Namespace */
+    color: $code-0C;
+  }
+
+  .kt {     /* Keyword.Type */
+    color: $code-0A;
+  } 
+
+  /**
+   * Operators
+   */
+
+  .o,       /* Operator */
+  .ow {     /* Operator.Word */
+    color: $code-0C
+  }
+
+  /**
+   * Names
+   */
+
+  .n,       /* Name */
+  .nb,      /* Name.Builtin */
+  .bp,      /* Name.Builtin.Pseudo */
+  .ni,      /* Name.Entity */
+  .nl,      /* Name.Label */
+  .py {     /* Name.Property */
+    // Default styling
+  }
+  
+  .nc,      /* Name.Class */
+  .nn {     /* Name.Namespace */
+    color: $code-0A;
+  }
+
+  .na,      /* Name.Attribute */
+  .nf {     /* Name.Function */
+    color: $code-0D;
+  }
+
+  .nv,      /* Name.Variable */
+  .no,      /* Name.Constant */
+  .vc,      /* Name.Variable.Class */
+  .vg,      /* Name.Variable.Global */
+  .vi {     /* Name.Variable.Instance */
+    color: $code-08;
+  }
+  
+  .nd {     /* Name.Decorator */
+    color: $code-0C;
+  }
+  
+  .nt,      /* Name.Tag */  
+  .nx {     /* Name.Other */
+    color: $code-0D;
+  }
+
+  .ne {     /* Name.Exception */
+    color: $code-0F;
+  }
+  
+  /**
+   * Literals
+   */
+  
+  .l  {     /* Literal */
+    color: $code-09;
+  }
+
+  .ld {     /* Literal.Date */
+    color: $code-0B;
+  }
+  
+  .m,       /* Literal.Number */
+  .mf,      /* Literal.Number.Float */
+  .mh,      /* Literal.Number.Hex */
+  .mi,      /* Literal.Number.Integer */
+  .il,      /* Literal.Number.Integer.Long */
+  .mo {     /* Literal.Number.Oct */
+    color: $code-09;
+  }
+  
+  .s,       /* Literal.String */
+  .sb,      /* Literal.String.Backtick */
+  .s2,      /* Literal.String.Double */
+  .sh {     /* Literal.String.Heredoc */
+    color: $code-0B;
+  }
+  
+  .sx,      /* Literal.String.Other */
+  .sr,      /* Literal.String.Regex */
+  .s1,      /* Literal.String.Single */
+  .ss {     /* Literal.String.Symbol */
+    color: $code-0B;
+  }
+
+  .se,      /* Literal.String.Escape */
+  .si {     /* Literal.String.Interpol */
+    color: $code-09;
+  }
+
+  .sd {     /* Literal.String.Doc */
+    color: $code-03
+  }
+  
+  .sc {     /* Literal.String.Char */
+    // Default styling
+  }
+  
+  /**
+   * Diffs
+   */
+
+  .gi {     /* Generic.Inserted */
+    background-color: $code-insert-bg;
+  }
+
+  .gd {     /* Generic.Deleted */
+    background-color: $code-delete-bg;
+  }
+  
+  /**
+   * Misc
+   */
+  
+  .p {      /* Punctuation */
+    // Default styling
+  }
+
+  .w {      /* Text.Whitespace */
+    // Default styling
+  }
+
+  .hll {    /* Highlight */
+    background-color: $code-02;
+  }
+
+  .err,     /* Error */
+  .gr,      /* Generic.Error */
+  .gt {     /* Generic.Traceback */
+    color: $code-0F;
+  }
+  
+  .gs {     /* Generic.Strong */
+    font-weight: bold;
+  }
+
+  .ge {     /* Generic.Emph */
+    font-style: italic;
+  }
+  
+  .gh {     /* Generic.Heading */
+    font-weight: bold;
+  }
+
+  .gu {     /* Generic.Subheading */
+    color: $code-0A;
+    font-weight: bold;
+  }
+  
+  .gp {     /* Generic.Prompt */
+    color: $code-03;
+    font-weight: bold
+  }
+}

--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -55,8 +55,12 @@
     border: 1px solid $code-02;
   }
 
+  pre code {
+    background: none;
+  }
+
   code {
-    background: $code-00;
+    background: $code-01;
     padding: 3px 3px;
     border-radius: 3px;
 

--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -48,14 +48,15 @@
   }
 
   pre {
-    background: $grey-4;
+    background: $code-00;
     padding: 15px;
     overflow: auto;
     position: relative;
+    border: 1px solid $code-02;
   }
 
   code {
-    background: $grey-4;
+    background: $code-00;
     padding: 3px 3px;
     border-radius: 3px;
 

--- a/source/stylesheets/palette/syntax-highlighting.scss
+++ b/source/stylesheets/palette/syntax-highlighting.scss
@@ -1,0 +1,23 @@
+// A Base16 palette
+// https://github.com/chriskempson/base16
+
+$code-00: scale-color($highlight-colour, $lightness:50%); /* Default Background */
+$code-01: #f5f5f5; /* Lighter Background (Unused) */
+$code-02: #bfc1c3; /* Selection Background */
+$code-03: darken($secondary-text-colour, 2%);; /* Comments, Invisibles, Line Highlighting */
+$code-04: #e8e8e8; /* Dark Foreground (Unused) */
+$code-05: $text-colour; /* Default Foreground, Caret, Delimiters, Operators */
+$code-06: #ffffff; /* Light Foreground (Unused) */
+$code-07: #ffffff; /* Light Background (Unused) */
+
+$code-08: #B23F29; /* Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted */
+$code-09: #0F7977; /* Integers, Boolean, Constants, XML Attributes, Markup Link Url */
+$code-0A: #795da3; /* Classes, Markup Bold, Search Text Background */
+$code-0B: $govuk-blue; /* Strings, Inherited Class, Markup Code, Diff Inserted */
+$code-0C: $govuk-blue; /* Support, Regular Expressions, Escape Characters, Markup Quotes */
+$code-0D: #795da3; /* Functions, Methods, Attribute IDs, Headings */
+$code-0E: #a71d5d; /* Keywords, Storage, Selector, Markup Italic, Diff Changed */
+$code-0F: darken($mellow-red, 2%);; /* Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?> (Unused) */
+
+$code-insert-bg: #DEF8CA;
+$code-delete-bg: #FADDDD;

--- a/source/stylesheets/palette/syntax-highlighting.scss
+++ b/source/stylesheets/palette/syntax-highlighting.scss
@@ -10,14 +10,14 @@ $code-05: $text-colour; /* Default Foreground, Caret, Delimiters, Operators */
 $code-06: #ffffff; /* Light Foreground (Unused) */
 $code-07: #ffffff; /* Light Background (Unused) */
 
-$code-08: #B23F29; /* Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted */
-$code-09: #0F7977; /* Integers, Boolean, Constants, XML Attributes, Markup Link Url */
-$code-0A: #795da3; /* Classes, Markup Bold, Search Text Background */
-$code-0B: $govuk-blue; /* Strings, Inherited Class, Markup Code, Diff Inserted */
+$code-08: #B26749; /* Variables, XML Tags, Markup Link Text, Markup Lists */
+$code-09: #0E7754; /* Integers, Boolean, Constants, XML Attributes, Markup Link Url */
+$code-0A: #4C4077; /* Classes, Markup Bold, Search Text Background */
+$code-0B: $govuk-blue; /* Strings, Inherited Class, Markup Code */
 $code-0C: $govuk-blue; /* Support, Regular Expressions, Escape Characters, Markup Quotes */
-$code-0D: #795da3; /* Functions, Methods, Attribute IDs, Headings */
-$code-0E: #a71d5d; /* Keywords, Storage, Selector, Markup Italic, Diff Changed */
-$code-0F: darken($mellow-red, 2%);; /* Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?> (Unused) */
+$code-0D: #4C4077; /* Functions, Methods, Attribute IDs, Headings */
+$code-0E: #a71d5d; /* Keywords, Storage, Selector, Markup Italic */
+$code-0F: #C92424; /* Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?> (Unused) */
 
 $code-insert-bg: #DEF8CA;
 $code-delete-bg: #FADDDD;


### PR DESCRIPTION
Use the middleman-syntax gem to automatically highlight blocks of code using [Rouge][1].

The HTML output that rouge creates is compatible with the python syntax highlighter ‘Pygments’. In order to ensure that the highlighting makes sense we build on top of [Base 16][2] to map pygments to a palette of sixteen colours.

The palette is then based loosely on both the GitHub colour palette and work that @edwardhorsford did, ensuring that all combinations meet colour contrast standards. Ed is still tweaking the palette but we need to start using this today, so another PR will likely follow with those tweaks.

[1]: https://github.com/jneen/rouge
[2]: https://github.com/chriskempson/base16

![screen shot 2016-12-07 at 10 41 35](https://cloud.githubusercontent.com/assets/121939/20964513/bfe126a2-bc69-11e6-9065-b4ab3e1cfae6.png)
