### PR TITLE
Use file-url helper from frontend toolkit

### DIFF
--- a/source/stylesheets/modules/_anchored-heading.scss
+++ b/source/stylesheets/modules/_anchored-heading.scss
@@ -18,12 +18,12 @@
     text-decoration: none;
     text-indent: -9999em;
 
-    background-image: image-url('anchored-heading-icon.png');
+    background-image: file-url('anchored-heading-icon.png');
     background-repeat: no-repeat;
     background-position: left center;
 
     @include device-pixel-ratio {
-      background-image: image-url('anchored-heading-icon-2x.png');
+      background-image: file-url('anchored-heading-icon-2x.png');
       background-size: $icon-width $icon-height;
     }
 

--- a/source/stylesheets/modules/_govuk-logo.scss
+++ b/source/stylesheets/modules/_govuk-logo.scss
@@ -2,11 +2,11 @@
   font-weight: bold;
 
   @include screen {
-    background-image: url('/images/gov.uk_logotype_crown.png');
+    background-image: file-url('/images/gov.uk_logotype_crown.png');
     background-repeat: no-repeat;
     
     @include device-pixel-ratio {
-      background-image: url('/images/gov.uk_logotype_crown-2x.png');
+      background-image: file-url('/images/gov.uk_logotype_crown-2x.png');
       background-size: 36px 32px;
     }
 

--- a/source/stylesheets/modules/_toc.scss
+++ b/source/stylesheets/modules/_toc.scss
@@ -97,12 +97,12 @@
           height: 20px;
           float: right;
           
-          background-image: image-url('govuk-icn-numbered-list.png');
+          background-image: file-url('govuk-icn-numbered-list.png');
           background-repeat: no-repeat;
           background-position: left center;
 
           @include device-pixel-ratio {
-            background-image: image-url('govuk-icn-numbered-list@2x.png');
+            background-image: file-url('govuk-icn-numbered-list@2x.png');
             background-size: 20px 20px;
           }
         }
@@ -120,12 +120,12 @@
         
         text-indent: -10000px;
         
-        background-image: image-url('govuk-icn-close.png');
+        background-image: file-url('govuk-icn-close.png');
         background-repeat: no-repeat;
         background-position: left center;
 
         @include device-pixel-ratio {
-          background-image: image-url('govuk-icn-close@2x.png');
+          background-image: file-url('govuk-icn-close@2x.png');
           background-size: 20px 20px;
         }
       }


### PR DESCRIPTION
This will output as if `image-url` is used in most cases, but will allow other projects consuming this to override `$path` to specify the location of their image assets.

Fixes #35