### PR TITLE
Add rel="noopener" when linking to images

### DIFF
--- a/lib/tech_docs_html_renderer.rb
+++ b/lib/tech_docs_html_renderer.rb
@@ -4,6 +4,6 @@ class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
   include Redcarpet::Render::SmartyPants
 
   def image(link, *args)
-    %(<a href="#{link}" target="_blank">#{super}</a>)
+    %(<a href="#{link}" target="_blank" rel="noopener noreferrer">#{super}</a>)
   end
 end


### PR DESCRIPTION
We're using target="_blank" to open images in a new window. There are known issues with being able to exploit such links using `window.opener' (https://mathiasbynens.github.io/rel-noopener/)

Whilst the images are *probably* going to be hosted within the same repo and under our control, we can't really guarantee it. Adding rel="noopener" is not detrimental, so let's play it safe.