### PR TITLE
Increase font size of level 1 in table of contents

### DIFF
--- a/source/stylesheets/modules/_toc.scss
+++ b/source/stylesheets/modules/_toc.scss
@@ -30,7 +30,7 @@
       }
 
       > ul > li > a {
-        @include bold-16;
+        @include bold-19;
       }
 
       // Second Level


### PR DESCRIPTION
Making it 19px instead of 16px (on desktop) makes the hierachy clearer.