### PR TITLE
Fix rubber banding in iOS.

### DIFF
--- a/source/javascripts/modules/table-of-contents.js
+++ b/source/javascripts/modules/table-of-contents.js
@@ -3,16 +3,42 @@
 
   Modules.TableOfContents = function () {
     var $html = $('html');
+    var $toc;
 
     this.start = function ($element) {
       var $closeLink = $element.find('.js-toc-close');
       var $tocList = $element.find('.js-toc-list');
+
+      $toc = $element;
+
+      fixRubberBandingInIOS();
 
       // Need delegated handler for show link as sticky polyfill recreates element
       $html.on('click.toc', '.js-toc-show', preventingScrolling(openNavigation));
       $closeLink.on('click.toc', preventingScrolling(closeNavigation));
       $tocList.on('click.toc', 'a', closeNavigation);
     };
+
+    function fixRubberBandingInIOS() {
+      // By default when the table of contents is at the top or bottom,
+      // scrolling in that direction will scroll the body 'behind' the table of
+      // contents. Fix this by preventing ever reaching the top or bottom of the
+      // table of contents (by 1 pixel).
+      // 
+      // http://blog.christoffer.me/six-things-i-learnt-about-ios-safaris-rubber-band-scrolling/
+      $toc.on("touchstart.toc", function () {
+        var $this = $(this),
+          top = $this.scrollTop(),
+          totalScroll = $this.prop('scrollHeight'),
+          currentScroll = top + $this.prop('offsetHeight');
+
+        if (top === 0) {
+          $this.scrollTop(1);
+        } else if (currentScroll === totalScroll) {
+          $this.scrollTop(top - 1);
+        }
+      });
+    }
 
     function openNavigation() {
       $html.addClass('toc-open');

--- a/source/stylesheets/modules/_toc.scss
+++ b/source/stylesheets/modules/_toc.scss
@@ -108,12 +108,16 @@
         }
       }
 
+      .toc__list {
+        margin-right: $gutter * 1.5;
+      }
+
       .toc__close {
         display: block;
-        position: fixed;
-        right: $gutter-half;
-        top: $gutter-half;
-        
+        position: sticky;
+        right: 0;
+        top: 0;
+
         width: 20px;
         height: 20px;
         float: right;
@@ -145,7 +149,6 @@
         
         .toc {
           display: block;
-          padding-right: $gutter * 2;
           position: fixed;
           top: 0;
           bottom: 0;


### PR DESCRIPTION
By default when the table of contents is at the top or bottom, scrolling in that direction will scroll the body 'behind' the table of contents. Fix this by preventing ever reaching the top or bottom of the table of contents (by 1 pixel) using javascript [1]. Non-JS users will just experience the (slightly) funky scrolling behaviour.

[1]: http://blog.christoffer.me/six-things-i-learnt-about-ios-safaris-rubber-band-scrolling/