### PR TITLE
Add support and basic styling for tables

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -9,7 +9,8 @@ set :markdown,
     renderer: TechDocsHTMLRenderer.new(
       with_toc_data: true
     ),
-    fenced_code_blocks: true
+    fenced_code_blocks: true,
+    tables: true
 
 # Per-page layout changes:
 #

--- a/lib/tech_docs_html_renderer.rb
+++ b/lib/tech_docs_html_renderer.rb
@@ -6,4 +6,12 @@ class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
   def image(link, *args)
     %(<a href="#{link}" target="_blank">#{super}</a>)
   end
+
+  def table(header, body)
+    %(<div class="table-container">
+      <table>
+        #{header}#{body}
+      </table>
+    </div>)
+  end
 end

--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -75,4 +75,55 @@
     /* Instead use this non-standard one: */
     word-break: break-word;
   }
+
+  .table-container {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  table {    
+    width: 100%;
+
+    margin-bottom: $gutter * 2;
+
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  th, td {
+    padding: $gutter-one-third $gutter-two-thirds $gutter-one-third 0;
+
+    background-color: transparent;
+    border-bottom: 1px solid $grey-2;
+    border-width: 0 0 1px 0;
+
+    @include core-16;
+    vertical-align: top;
+    text-align: left;
+  }
+
+  th {
+    font-weight: bold;
+  }
+
+  td {
+    p, ul, ol {
+      margin: 0;
+    }
+    p+p, p+ul, p+ol,
+    ul+p, ul+ol,
+    ol+p {
+      margin-top: $gutter-one-third;
+    }
+  }
+
+  hr {
+    height: 1px;
+    border: none;
+    margin-top: $gutter - 1px;
+    margin-bottom: $gutter;
+    background-color: $border-colour;
+    color: $border-colour;
+  }
 }


### PR DESCRIPTION
Enable table support in Redcarpet, wrap the table with a container so that we can make it ‘scroll’ on mobile, and add basic styling (copied from Whitehall)