### PR TITLE
Create a generic layout to use

### DIFF
--- a/template/source/layouts/header_footer_only.erb
+++ b/template/source/layouts/header_footer_only.erb
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en" class="no-js">
+  <head>
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+
+    <!-- Use title if it's in the page YAML frontmatter -->
+    <title><%= current_page.data.title || "GOV.UK Documentation" %></title>
+
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
+    <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
+
+    <link rel="canonical" href="<%= config[:tech_docs][:host] %><%= current_page.url %>">
+
+    <%= stylesheet_link_tag :print, media: 'print' %>
+
+    <%= javascript_include_tag :application %>
+  </head>
+
+  <body>
+    <div class="app-pane">
+      <div class="app-pane__header">
+        <a href="#content" class="skip-link">Skip to main content</a>
+
+        <header class="header header--full-width">
+          <div class="header__container">
+            <div class="header__brand">
+              <% if config[:tech_docs][:service_link] %>
+                <a href="<%= config[:tech_docs][:service_link] %>">
+              <% else %>
+                <span>
+              <% end %>
+                <% if config[:tech_docs][:show_govuk_logo] %>
+                  <span class="govuk-logo">
+                    <img class="govuk-logo__printable-crown" src="/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
+                    GOV.UK
+                  </span>
+                <% end %>
+                <span class="header__title">
+                  <%= config[:tech_docs][:service_name] %>
+                  <% if config[:tech_docs][:phase] %>
+                    <span class="phase-banner"><%= config[:tech_docs][:phase] %></span>
+                  <% end %>
+                </span>
+              <% if config[:tech_docs][:service_link] %>
+                </a>
+              <% else %>
+                </span>
+              <% end %>
+            </div>
+
+            <input class="header__navigation-toggle-checkbox" type="checkbox" id="show-menu" />
+            <label class="header__navigation-toggle" for="show-menu">
+              Menu
+            </label>
+
+            <% if config[:tech_docs][:header_links] %>
+              <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation">
+                <ul>
+                  <% config[:tech_docs][:header_links].each do |title, url| %>
+                    <li<% if url == current_page.url %> class="active"<% end %>>
+                      <a href="<%= url %>">
+                        <%= title %>
+                      </a>
+                    </li>
+                  <% end %>
+                </ul>
+              </nav>
+            <% end %>
+          </div>
+        </header>
+      </div>
+
+      <%= yield %>
+    </div>
+
+
+  </body>
+</html>

--- a/template/source/layouts/layout.erb
+++ b/template/source/layouts/layout.erb
@@ -1,103 +1,26 @@
-<!doctype html>
-<html lang="en" class="no-js">
-  <head>
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
-    <meta charset="utf-8">
-    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+<% layout :header_footer_only do %>
+  <div id="toc-heading" class="toc-show fixedsticky">
+    <a href="#toc" class="toc-show__label js-toc-show">
+      Table of contents <span class="toc-show__icon"></span>
+    </a>
+  </div>
 
-    <!-- Use title if it's in the page YAML frontmatter -->
-    <title><%= current_page.data.title || "GOV.UK Documentation" %></title>
+  <% html = yield %>
 
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
-    <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
-
-    <link rel="canonical" href="<%= config[:tech_docs][:host] %><%= current_page.url %>">
-
-    <%= stylesheet_link_tag :print, media: 'print' %>
-
-    <%= javascript_include_tag :application %>
-  </head>
-
-  <body>
-    <div class="app-pane">
-      <div class="app-pane__header">
-        <a href="#content" class="skip-link">Skip to main content</a>
-
-        <header class="header header--full-width">
-          <div class="header__container">
-            <div class="header__brand">
-              <% if config[:tech_docs][:service_link] %>
-                <a href="<%= config[:tech_docs][:service_link] %>">
-              <% else %>
-                <span>
-              <% end %>
-                <% if config[:tech_docs][:show_govuk_logo] %>
-                  <span class="govuk-logo">
-                    <img class="govuk-logo__printable-crown" src="/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
-                    GOV.UK
-                  </span>
-                <% end %>
-                <span class="header__title">
-                  <%= config[:tech_docs][:service_name] %>
-                  <% if config[:tech_docs][:phase] %>
-                    <span class="phase-banner"><%= config[:tech_docs][:phase] %></span>
-                  <% end %>
-                </span>
-              <% if config[:tech_docs][:service_link] %>
-                </a>
-              <% else %>
-                </span>
-              <% end %>
-            </div>
-
-            <input class="header__navigation-toggle-checkbox" type="checkbox" id="show-menu" />
-            <label class="header__navigation-toggle" for="show-menu">
-              Menu
-            </label>
-
-            <% if config[:tech_docs][:header_links] %>
-              <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation">
-                <ul>
-                  <% config[:tech_docs][:header_links].each do |title, url| %>
-                    <li<% if url == current_page.url %> class="active"<% end %>>
-                      <a href="<%= url %>">
-                        <%= title %>
-                      </a>
-                    </li>
-                  <% end %>
-                </ul>
-              </nav>
-            <% end %>
-          </div>
-        </header>
-      </div>
-
-      <div id="toc-heading" class="toc-show fixedsticky">
-        <a href="#toc" class="toc-show__label js-toc-show">
-          Table of contents <span class="toc-show__icon"></span>
-        </a>
-      </div>
-
-      <% html = yield %>
-
-      <div class="app-pane__body" data-module="highlighted-nav">
-        <div class="app-pane__toc">
-          <div class="toc" data-module="table-of-contents">
-            <a href="#" class="toc__close js-toc-close">Close</a>
-            <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
-              <%= table_of_contents(html) %>
-            </nav>
-          </div>
-        </div>
-
-        <div class="app-pane__content">
-          <main id="content" class="technical-documentation" data-module="anchored-headings">
-            <%= html %>
-          </main>
-        </div>
+  <div class="app-pane__body" data-module="highlighted-nav">
+    <div class="app-pane__toc">
+      <div class="toc" data-module="table-of-contents">
+        <a href="#" class="toc__close js-toc-close">Close</a>
+        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
+          <%= table_of_contents(html) %>
+        </nav>
       </div>
     </div>
 
-
-  </body>
-</html>
+    <div class="app-pane__content">
+      <main id="content" class="technical-documentation" data-module="anchored-headings">
+        <%= html %>
+      </main>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This separates a common layout (with header, footer, stylesheet and javascript includes) from the tech-docs layout (table of contents and content).

It allows users to generate pages with a different way of building the table of contents (or none at all).

Primary use case is the alphagov/govuk-developers project, which generates a [custom table of contents](https://github.com/alphagov/govuk-developers/blob/7812aedae055605b31590eec4f5bbc125ed0117c/source/index.html.erb#L9-L26).

I've also considered flipping the naming of the templates, so that `layout.erb` is the base template, and the tech docs layout is the special case. You can see it in this branch: 

https://github.com/alphagov/tech-docs-template/compare/layout-alt-option

That option has my preference, but it does introduce a new config option in `config.rb`. This PR may be the less controversial option.