### PR TITLE
Create site on CI to make sure template builds correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
  - 2.3.3
-script: bundle exec rake jasmine:ci
+script:
+  - bundle exec rake jasmine:ci
+  - ./create-test-site.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for the name of your new project:
 ```bash
 mkdir my-new-project
 cd my-new-project
-middleman init . -T alphagov/tech-docs-template
+FIRST_TIME=true middleman init . -T alphagov/tech-docs-template
 ```
 
 This will run an interactive prompt where you can set basic configuration for
@@ -37,12 +37,8 @@ In order to configure things like the header, edit `config/tech-docs.yml`.
 From your project folder, run:
 
 ```
-middleman init . -T alphagov/tech-docs-template
+FIRST_TIME=false middleman init . -T alphagov/tech-docs-template
 ```
-
-When asked 'Are you creating a completely new documentation project?', be sure
-to answer **no** to avoid having the default 'demo' documentation and config
-being created.
 
 If you have made any changes to the layout or any of the assets you will be
 prompted to resolve any conflicts, at which point you can view a diff between

--- a/Thorfile
+++ b/Thorfile
@@ -7,7 +7,11 @@ module Middleman
     source_root File.expand_path(File.dirname(__FILE__))
 
     def detect_if_first_time_install
-      @first_time = yes?('Are you creating a completely new documentation project?')
+      if option_set?('FIRST_TIME')
+        @first_time = parse_boolean('FIRST_TIME')
+      else
+        @first_time = yes?('Are you creating a completely new documentation project?')
+      end
     end
 
     def copy_template_files
@@ -17,11 +21,15 @@ module Middleman
     def ask_about_paas
       return unless @first_time
 
-      @use_paas = yes?('Will you be deploying this on Government PaaS?')
+      if option_set?('USE_PAAS')
+        @use_paas = parse_boolean('USE_PAAS')
+      else
+        @use_paas = yes?('Will you be deploying this on Government PaaS?')
+      end
 
       return unless @use_paas
 
-      @application_name = ask(
+      @application_name = ENV['APPLICATION_NAME'] || ask(
         <<-MESSAGE
 What is the name of your application on PaaS?
 If your application URL is larry-the-cat.cloudapps.digital, this will be "larry-the-cat".
@@ -32,7 +40,7 @@ If your application URL is larry-the-cat.cloudapps.digital, this will be "larry-
     def ask_about_canonical_host
       return unless @first_time
 
-      @canonical_host = ask(
+      @canonical_host = ENV['CANONICAL_HOST'] || ask(
         <<-MESSAGE
 What is the canonical hostname of your application?
 e.g. docs.larry-the-cat.service.gov.uk
@@ -61,6 +69,16 @@ e.g. docs.larry-the-cat.service.gov.uk
 
       directory 'optional/source', 'source'
       copy_file 'optional/README.md', 'README.md'
+    end
+
+  private
+
+    def option_set?(key)
+      ENV.key?(key)
+    end
+
+    def parse_boolean(key)
+      ENV[key] == 'true'
     end
   end
 end

--- a/create-test-site.sh
+++ b/create-test-site.sh
@@ -1,0 +1,26 @@
+# This script is run by Travis. It generates a brand new site from the
+# template so that we can be confident that the project works out of the box.
+
+# The `middleman init` script can be configured with environment variables
+# instead of the interactive prompt.
+export FIRST_TIME=true
+export USE_PAAS=true
+export APPLICATION_NAME=larry-the-cat
+export CANONICAL_HOST=larry-the-cat.cloudapps.digital
+
+# When Travis runs the "/push" tests it runs inside a repo cloned with
+# --depth=1, which means middleman can't clone the template in this directory.
+# This fixes that but will fail on "/pr" tests, but we can ignore that.
+git fetch --unshallow
+
+# The `bundle` commands inside `tmp/test-run` don't work as expected on Travis
+# because it sets the `BUNDLE_GEMFILE` env variable to Gemfile in the root of
+# the project. We have to override it manually to install the proper gems in the
+# generated site.
+#
+# See https://docs.travis-ci.com/user/languages/ruby/#%24BUNDLE_GEMFILE-environment-variable
+gem install middleman &&
+middleman init tmp/test-run -T file://$(pwd) &&
+cd tmp/test-run &&
+BUNDLE_GEMFILE=./Gemfile bundle install &&
+BUNDLE_GEMFILE=./Gemfile bundle exec middleman build --verbose


### PR DESCRIPTION
In #50 I introduced a bug in the template by using `layout` instead of `wrap_layout`.

This commit adds steps to the test run on Travis to generate an example site. This would've caught the bug before merging.
