### PR TITLE
Add Google Analytics

### DIFF
--- a/optional/config/tech-docs.yml.tt
+++ b/optional/config/tech-docs.yml.tt
@@ -14,5 +14,5 @@ header_links:
   Documentation: /
   Support: https://www.larry-the-cat.service.gov.uk/support
 
-# Tracking ID from Google Analytics
-ga_tracking_id: UA-XXXXX-Y
+# Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
+ga_tracking_id:

--- a/optional/config/tech-docs.yml.tt
+++ b/optional/config/tech-docs.yml.tt
@@ -13,3 +13,6 @@ header_links:
   Get Started: https://www.larry-the-cat.service.gov.uk/get-started
   Documentation: /
   Support: https://www.larry-the-cat.service.gov.uk/support
+
+# Tracking ID from Google Analytics
+ga_tracking_id: UA-XXXXX-Y

--- a/template/source/layouts/header_footer_only.erb
+++ b/template/source/layouts/header_footer_only.erb
@@ -75,14 +75,16 @@
       <%= yield %>
     </div>
 
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <% if config[:tech_docs].key?(:ga_tracking_id) && !config[:tech_docs][:ga_tracking_id].empty? %>
+      <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
-    ga('send', 'pageview');
-    </script>
+      ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
+      ga('send', 'pageview');
+      </script>
+    <% end %>
   </body>
 </html>

--- a/template/source/layouts/header_footer_only.erb
+++ b/template/source/layouts/header_footer_only.erb
@@ -75,6 +75,14 @@
       <%= yield %>
     </div>
 
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+    ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
+    ga('send', 'pageview');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This adds a GA snippet, and a config option (`ga_tracking_id`) which
allows us to get information about site usage through GA.