### PR TITLE
Add configurable ToC max heading level

### DIFF
--- a/optional/config/tech-docs.yml.tt
+++ b/optional/config/tech-docs.yml.tt
@@ -16,3 +16,8 @@ header_links:
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:
+
+# Table of contents depth – how many levels to include in the table of contents.
+# If your ToC is too long, reduce this number and we'll only show higher-level
+# headings.
+max_toc_heading_level: 6

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -18,4 +18,4 @@ gem 'middleman-syntax', '~> 3.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
 
-gem 'table_of_contents', github: 'alphagov/table_of_contents'
+gem 'table_of_contents', github: 'alphagov/table_of_contents', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'

--- a/template/source/layouts/layout.erb
+++ b/template/source/layouts/layout.erb
@@ -12,7 +12,12 @@
       <div class="toc" data-module="table-of-contents">
         <a href="#" class="toc__close js-toc-close">Close</a>
         <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
-          <%= table_of_contents(html) %>
+          <%=
+            table_of_contents(
+              html,
+              max_level: config[:tech_docs][:max_toc_heading_level]
+            )
+          %>
         </nav>
       </div>
     </div>


### PR DESCRIPTION
There's a desire to be able to set a maximum heading level to include in
the left-hand table of contents – this is implemented in the
table_of_contents gem (see alphagov/table_of_contents#4), and is now
configurable here via the `max_toc_heading_level` option.