### PR TITLE
Fix scroll history bug

### DIFF
--- a/template/source/javascripts/modules/in-page-navigation.js
+++ b/template/source/javascripts/modules/in-page-navigation.js
@@ -13,14 +13,14 @@
 
       $contentPane.on('scroll', _.debounce(handleScrollEvent, 250, { maxWait: 250 }));
 
-      // Popstate is triggered when using the back button to navigate 'within'
-      // the page, i.e. changing the anchor part of the URL.
-      $(window).on('popstate', function (event) {
-        restoreScrollPosition(event.originalEvent.state);
-      });
-
-      // Restore state when e.g. using the back button to return to this page
       if (Modernizr.history) {
+        // Popstate is triggered when using the back button to navigate 'within'
+        // the page, i.e. changing the anchor part of the URL.
+        $(window).on('popstate', function (event) {
+          restoreScrollPosition(event.originalEvent.state);
+        });
+
+        // Restore state when e.g. using the back button to return to this page
         restoreScrollPosition(history.state);
       }
     };
@@ -28,6 +28,8 @@
     function restoreScrollPosition(state) {
       if (state && state.scrollTop) {
         $contentPane.scrollTop(state.scrollTop);
+      } else {
+        $contentPane.scrollTop(0);
       }
     }
 


### PR DESCRIPTION
If the user navigates within the page before they scroll, the scroll position will not be recorded in their history state object so clicking the back button will not take them back to the top of the page as they might expect it to.

We can work around this by scrolling to the top of the page when an empty state is popped from the history api.