### PR TITLE
Store initial scroll state on page load

### DIFF
--- a/template/source/javascripts/modules/in-page-navigation.js
+++ b/template/source/javascripts/modules/in-page-navigation.js
@@ -20,16 +20,20 @@
           restoreScrollPosition(event.originalEvent.state);
         });
 
-        // Restore state when e.g. using the back button to return to this page
-        restoreScrollPosition(history.state);
+        if (history.state && history.state.scrollTop) {
+          // Restore existing state when e.g. using the back button to return to
+          // this page
+          restoreScrollPosition(history.state);
+        } else {
+          // Store initial position so we can restore it when using back button
+          handleScrollEvent();
+        }
       }
     };
 
     function restoreScrollPosition(state) {
-      if (state && state.scrollTop) {
+      if (state && typeof state.scrollTop !== 'undefined') {
         $contentPane.scrollTop(state.scrollTop);
-      } else {
-        $contentPane.scrollTop(0);
       }
     }
 


### PR DESCRIPTION
The previous solution worked in Chrome, but Firefox and Safari fire pop state events when a anchor link is clicked, which means you can’t use the navigation. At all. Oops.

Instead of assuming that when there is no scrollTop stored we should scroll to the top, explicitly store the scroll position on page load if no existing state is present. Also allow restoreScrollPosition to scroll to the top as a value of 0 for scrollTop would be falsey.