### PR TITLE
Fix ARIA label for top level nav

### DIFF
--- a/template/source/layouts/header_footer_only.erb
+++ b/template/source/layouts/header_footer_only.erb
@@ -56,7 +56,7 @@
             </label>
 
             <% if config[:tech_docs][:header_links] %>
-              <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation">
+              <nav id="navigation" class="header__navigation" aria-label="Top level">
                 <ul>
                   <% config[:tech_docs][:header_links].each do |title, url| %>
                     <li<% if url == current_page.url %> class="active"<% end %>>


### PR DESCRIPTION
“The label is "Top level navigation", which means that screen readers announce something like "Top level navigation navigation". They identify the fact it's a navigation region because of the <nav> and/or role="navigation, so there is no need to include the word "navigation" in the label.”

(Thanks, Léonie)