### PR TITLE
Add GA event tracking

### DIFF
--- a/template/source/javascripts/analytics.js
+++ b/template/source/javascripts/analytics.js
@@ -1,0 +1,31 @@
+(function($) {
+  function trackLinkClick(action, $element) {
+    var linkText = $.trim($element.text());
+    var linkURL = $element.attr('href');
+    var label = linkText + '|' + linkURL;
+
+    ga(
+      'send',
+      'event',
+      'SM Technical Documentation', // Event Category
+      action, // Event Action
+      label // Event Label
+    );
+  }
+
+  function linkTrackingEventHandler(action) {
+    return function() {
+      trackLinkClick(action, $(this));
+    };
+  };
+
+  $(document).on('ready', function() {
+    if (typeof ga === 'undefined') {
+      return;
+    }
+
+    $('.technical-documentation a').on('click', linkTrackingEventHandler('inTextClick'));
+    $('.header a').on('click', linkTrackingEventHandler('topNavigationClick'));
+    $('.toc a').on('click', linkTrackingEventHandler('tableOfContentsNavigationClick'));
+  });
+})(jQuery);

--- a/template/source/javascripts/application.js
+++ b/template/source/javascripts/application.js
@@ -2,6 +2,7 @@
 //= require vendor/modernizr
 //= require vendor/fixedsticky
 //= require vendor/lodash
+//= require analytics
 //= require start-modules
 
 $(function() {


### PR DESCRIPTION
This adds some fairly rudimentary Google Analytics event tracking to the
template. It allows us to track clicks on links in the header, table of
contents and inside the generated markdown.

The events used are per this Trello card:
https://trello.com/c/oI9DMxao/479-analytics