### PR TITLE
Automatically scroll to active ToC link

### DIFF
--- a/template/source/javascripts/modules/in-page-navigation.js
+++ b/template/source/javascripts/modules/in-page-navigation.js
@@ -11,7 +11,7 @@
       $contentPane = $element.find('.app-pane__content');
       $tocItems = $tocPane.find('a');
 
-      $contentPane.on('scroll', _.debounce(handleScrollEvent, 250, { maxWait: 250 }));
+      $contentPane.on('scroll', _.debounce(handleScrollEvent, 100, { maxWait: 100 }));
 
       if (Modernizr.history) {
         // Popstate is triggered when using the back button to navigate 'within'
@@ -59,7 +59,28 @@
 
       if ($activeTocItem) {
         $activeTocItem.addClass('toc-link--in-view');
+        scrollTocToActiveItem($activeTocItem);
       }
+    }
+
+    function scrollTocToActiveItem($activeTocItem) {
+      var paneHeight = $tocPane.height();
+      var linkTop = $activeTocItem.position().top;
+      var linkBottom = linkTop + $activeTocItem.outerHeight();
+
+      var offset = null;
+
+      if (linkTop < 0) {
+        offset = linkTop;
+      } else if (linkBottom >= paneHeight) {
+        offset = -(paneHeight - linkBottom);
+      } else {
+        return;
+      }
+
+      var newScrollTop = $tocPane.scrollTop() + offset;
+
+      $tocPane.scrollTop(newScrollTop);
     }
 
     function tocItemForFirstElementInView() {


### PR DESCRIPTION
This adds some functionality to ensure we always have the active ToC
item in view when scrolling through the content pane, by scrolling the
ToC pane in sync with the content pane.

Additionally, it reduces the debounce timeout to 100ms, as 250ms makes
the scrolling appear a tad jerky.