### PR TITLE
Fix initial page position when linking to anchor

### DIFF
--- a/template/source/javascripts/modules/in-page-navigation.js
+++ b/template/source/javascripts/modules/in-page-navigation.js
@@ -25,8 +25,9 @@
           // this page
           restoreScrollPosition(history.state);
         } else {
-          // Store initial position so we can restore it when using back button
-          handleScrollEvent();
+          // Store the initial position so that we can restore it even if we
+          // never scroll.
+          handleInitialLoadEvent();
         }
       }
     };
@@ -37,15 +38,27 @@
       }
     }
 
-    function handleScrollEvent() {
-      var $activeTocItem = tocItemForFirstElementInView();
+    function handleInitialLoadEvent() {
+      var $activeTocItem = tocItemForTargetElement();
 
+      if ($activeTocItem.length == 0) {
+        $activeTocItem = tocItemForFirstElementInView();
+      }
+
+      handleChangeInActiveItem($activeTocItem);
+    }
+
+    function handleScrollEvent() {
+      handleChangeInActiveItem(tocItemForFirstElementInView());
+    }
+
+    function handleChangeInActiveItem($activeTocItem) {
       storeCurrentPositionInHistoryApi($activeTocItem);
       highlightActiveItemInToc($activeTocItem);
     }
 
     function storeCurrentPositionInHistoryApi($activeTocItem) {
-      if (Modernizr.history && $activeTocItem) {
+      if (Modernizr.history && $activeTocItem && $activeTocItem.length == 1) {
         history.replaceState(
           { scrollTop: $contentPane.scrollTop() },
           "",
@@ -81,6 +94,17 @@
       var newScrollTop = $tocPane.scrollTop() + offset;
 
       $tocPane.scrollTop(newScrollTop);
+    }
+
+    function tocItemForTargetElement() {
+      var target = window.location.hash
+      var $targetElement = $(target);
+
+      if ($targetElement) {
+        return $tocItems.filter(function (elem) {
+          return ($(this).attr('href') == target);
+        }).first();
+      }
     }
 
     function tocItemForFirstElementInView() {


### PR DESCRIPTION
The call to handleScrollEvent was previously causing the browser to jump back up to the start of the document. This seems to be because:

1) handleScrollEvent is called _before_ the browser has scrolled the user to the target heading
2) tocItemForFirstElementInView therefore returns the first heading on the page
3) the current history state is therefore updated with the hash of the first heading on the page
4) this appears to be enough to cause the browser to scroll back to the top of the document

We need slightly different behaviour when loading the page for the first time - if there is an anchor specified, we should use the hash and offset for that entry rather than trying to find the first element in view. We’ll fall back to the first element if there is no hash, or the hash does not link to somewhere in the ToC.