### PR TITLE
Improve letter-spacing on ToC items

### DIFF
--- a/template/source/stylesheets/modules/_toc.scss
+++ b/template/source/stylesheets/modules/_toc.scss
@@ -28,7 +28,7 @@
       a:link, a:visited {
         display: block;
         padding: 8px 0;
-        letter-spacing: 0.03em;
+        letter-spacing: 0.019em;
 
         &.toc-link--in-view {
           font-weight: bold;


### PR DESCRIPTION
At the moment, the ToC navigation "jumps" when transitioning to a
highlighted state as the bold version of the text is narrower than the
non-bold version. This fixes that, by reducing the letter-spacing to
ensure things are more consistent.