### PR TITLE
Add config to prevent indexing of docs

### DIFF
--- a/optional/config/tech-docs.yml.tt
+++ b/optional/config/tech-docs.yml.tt
@@ -21,3 +21,6 @@ ga_tracking_id:
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.
 max_toc_heading_level: 6
+
+# Prevent robots from indexing (e.g. whilst in development)
+prevent_indexing: false

--- a/template/source/layouts/header_footer_only.erb
+++ b/template/source/layouts/header_footer_only.erb
@@ -4,6 +4,9 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8">
     <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+    <% if config[:tech_docs][:prevent_indexing] %>
+      <meta name="robots" content="noindex">
+    <% end %>
 
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= current_page.data.title || "GOV.UK Documentation" %></title>


### PR DESCRIPTION
This is currently being manually added to the PaaS docs which makes upgrading difficult.