### PR TITLE
Remove text from anchor links

### DIFF
--- a/template/source/javascripts/modules/anchored-headings.js
+++ b/template/source/javascripts/modules/anchored-headings.js
@@ -11,7 +11,7 @@
       var $this = $(this);
       $this.addClass('anchored-heading');
       $this.prepend(
-        '<a href="#' + $this.attr('id') + '" class="anchored-heading__icon" aria-hidden="true">Link to here</a>'
+        '<a href="#' + $this.attr('id') + '" class="anchored-heading__icon" aria-hidden="true"></a>'
       );
     };
   };

--- a/template/source/stylesheets/modules/_anchored-heading.scss
+++ b/template/source/stylesheets/modules/_anchored-heading.scss
@@ -30,6 +30,12 @@
     @include media(tablet) {
       display: block;
     }
+
+    &:before {
+      // zero width space character so that the link behaves like it has text,
+      // has height, sits on the baseline, etc.
+      content: "\200b";
+    }
   }
 
   &:hover &__icon {


### PR DESCRIPTION
When Google decides to use the h1 of the document, it’s extracting ‘Link to here’ as part of the heading and including it in the title of the page in search results.

Remove ‘Link to here’ as it’s hidden from screen readers anyway, and users of assisted tech would be able to ‘create’ links to individual headings using the table of contents.

Fixes #85 