### PR TITLE
Update of bundler :github shortcut to use :git and https:// instead of git://

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -18,4 +18,4 @@ gem 'middleman-syntax', '~> 3.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
 
-gem 'table_of_contents', github: 'alphagov/table_of_contents', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'
+gem 'table_of_contents', git: 'https://github.com/alphagov/table_of_contents.git', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'


### PR DESCRIPTION
Minor update to address some problems which we ran across in building sites created using this template - internal proxies and also some security issues highlighted in http://bundler.io/v1.14/git.html#security.