### PR TITLE
Only diff changed files when updating template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ for the name of your new project:
 ```bash
 mkdir my-new-project
 cd my-new-project
-FIRST_TIME=true middleman init . -T alphagov/tech-docs-template
+middleman init . -T alphagov/tech-docs-template
 ```
 
 This will run an interactive prompt where you can set basic configuration for
@@ -41,7 +41,7 @@ In order to configure things like the header, edit `config/tech-docs.yml`.
 From your project folder, run:
 
 ```
-FIRST_TIME=false middleman init . -T alphagov/tech-docs-template
+middleman init . -T alphagov/tech-docs-template
 ```
 
 If you have made any changes to the layout or any of the assets you will be

--- a/Thorfile
+++ b/Thorfile
@@ -12,8 +12,7 @@ module Middleman
 
     class_option 'template',
                  aliases: '-T',
-                 default: 'middleman/middleman-templates-default',
-                 desc: 'Use a project template'
+                 default: 'alphagov/tech-docs-template'
 
     source_root __dir__
 

--- a/Thorfile
+++ b/Thorfile
@@ -8,6 +8,8 @@ module Middleman
   class Generator < ::Thor::Group
     include ::Thor::Actions
 
+    TEMPLATE_VERSION_FILE = '.template_version'.freeze
+
     class_option 'template',
                  aliases: '-T',
                  default: 'middleman/middleman-templates-default',
@@ -15,14 +17,13 @@ module Middleman
 
     source_root __dir__
 
-
     def detect_if_first_time_install
       @first_time = option_set?('FIRST_TIME') || !File.exist?('config.rb')
     end
 
     def clone_existing_version
-      return if @first_time
-      template = YAML.load_file('.template_version')
+      return if @first_time || !File.exist?(TEMPLATE_VERSION_FILE)
+      template = YAML.load_file(TEMPLATE_VERSION_FILE)
       dir = Dir.mktmpdir
       files = {}
 
@@ -124,8 +125,8 @@ e.g. docs.larry-the-cat.service.gov.uk
 
       raise 'Unable to get remote / revision' unless remote && revision
 
-      remove_file '.template_version'
-      create_file '.template_version', { remote: remote, revision: revision }.to_yaml
+      remove_file TEMPLATE_VERSION_FILE
+      create_file TEMPLATE_VERSION_FILE, { remote: remote, revision: revision }.to_yaml
     end
 
   private

--- a/Thorfile
+++ b/Thorfile
@@ -14,6 +14,11 @@ module Middleman
                  aliases: '-T',
                  default: 'alphagov/tech-docs-template'
 
+    class_option 'verbose',
+                 type: :boolean,
+                 alias: '-V',
+                 default: false
+
     source_root __dir__
 
     def detect_if_first_time_install
@@ -48,10 +53,10 @@ module Middleman
           if template_hash == local_hash
             remove_file(filename)
           else
-            puts "Keeping #{filename}, local changes made vs template"
+            log "Keeping #{filename}, local changes made vs template"
           end
         rescue Errno::ENOENT
-          puts "File #{filename} not found locally, doing nothing"
+          log "File #{filename} not found locally, doing nothing"
         end
       end
     end
@@ -136,6 +141,11 @@ e.g. docs.larry-the-cat.service.gov.uk
 
     def parse_boolean(key)
       ENV[key] == 'true'
+    end
+
+    def log(*args)
+      return unless options[:verbose]
+      puts(*args)
     end
   end
 end

--- a/Thorfile
+++ b/Thorfile
@@ -4,7 +4,12 @@ module Middleman
   class Generator < ::Thor::Group
     include ::Thor::Actions
 
-    source_root File.expand_path(File.dirname(__FILE__))
+    class_option 'template',
+                 aliases: '-T',
+                 default: 'middleman/middleman-templates-default',
+                 desc: 'Use a project template'
+
+    source_root __dir__
 
     def detect_if_first_time_install
       if option_set?('FIRST_TIME')
@@ -69,6 +74,21 @@ e.g. docs.larry-the-cat.service.gov.uk
 
       directory 'optional/source', 'source'
       copy_file 'optional/README.md', 'README.md'
+    end
+
+    def save_version_file
+      remote = nil
+      revision = nil
+
+      inside(__dir__) do
+        remote = run('git remote get-url origin', capture: true).strip
+        revision = run('git rev-parse head', capture: true).strip
+      end
+
+      raise 'Unable to get remote / revision' unless remote && revision
+
+      remove_file '.template_version'
+      create_file '.template_version', { remote: remote, revision: revision }.to_json
     end
 
   private

--- a/Thorfile
+++ b/Thorfile
@@ -25,7 +25,7 @@ module Middleman
       template = YAML.load_file('.template_version')
       dir = Dir.mktmpdir
       files = {}
-      
+
       begin
         run("git clone #{template[:remote]} #{dir}")
         inside(dir) do
@@ -42,12 +42,16 @@ module Middleman
       end
 
       files.each do |filename, template_hash|
-        local_hash = Digest::MD5.file(filename).hexdigest
+        begin
+          local_hash = Digest::MD5.file(filename).hexdigest
 
-        if template_hash == local_hash
-          remove_file(filename)
-        else
-          puts "Keeping #{filename}, local changes made vs template"
+          if template_hash == local_hash
+            remove_file(filename)
+          else
+            puts "Keeping #{filename}, local changes made vs template"
+          end
+        rescue Errno::ENOENT
+          puts "File #{filename} not found locally, doing nothing"
         end
       end
     end


### PR DESCRIPTION
This makes some changes to our `Thorfile` to ensure that we only prompt the user about files that they've actually changed rather than files that have changed in the template.

We do this by:
- Storing the last used template version in a `.template_version` file
- Cloning the last template
- Removing files from the local installation that are the same as the template
- Applying the latest version of the template

This means that the user won't be prompted for files that have updated in the template but they haven't changed locally.