### PR TITLE
Guard against no heading being seen as active

### DIFF
--- a/template/source/javascripts/modules/in-page-navigation.js
+++ b/template/source/javascripts/modules/in-page-navigation.js
@@ -118,7 +118,7 @@
         }
       });
 
-      return '#' + result.attr('id');
+      return result ? '#' + result.attr('id') : false;
     }
   };
 })(jQuery, window.GOVUK.Modules);


### PR DESCRIPTION
On mobile, we sometimes (?) don’t find any of the possible targets to be at the top of the screen, because their offset is the top of the page and there is a header between the first target and that.

Guarding to allow for result being nil fixes this. It means we don’t update the hash or the nav when the page first loads, but in the mobile viewport that’s not something we do as the user scrolls anyway.