### PR TITLE
Remove extra padding from multi line code blocks

### DIFF
--- a/template/source/stylesheets/modules/_technical-documentation.scss
+++ b/template/source/stylesheets/modules/_technical-documentation.scss
@@ -57,6 +57,7 @@
 
   pre code {
     background: none;
+    padding: 0;
   }
 
   code {


### PR DESCRIPTION
This removes some extra padding which otherwise ends up ‘indenting’ the first line of a multi line code block by 3px.