### PR TITLE
Revise highlight state for table of contents

### DIFF
--- a/template/source/stylesheets/modules/_toc.scss
+++ b/template/source/stylesheets/modules/_toc.scss
@@ -27,29 +27,57 @@
 
       a:link, a:visited {
         display: block;
-        padding: 8px 0;
-        letter-spacing: 0.019em;
+        padding: 8px $gutter-half;
+        margin: 0 $gutter-half * -1;
+        border-left: 5px solid transparent;
 
-        &.toc-link--in-view {
-          font-weight: bold;
-          color: $link-active-colour;
-          letter-spacing: normal;
+        @include media(tablet) {
+          &.toc-link--in-view {
+            color: $link-active-colour;
+            border-left-color: $link-active-colour;
+            background-color: $grey-4;
+          }
         }
       }
 
+      // Top level
       > ul > li > a:link {
         @include bold-19;
-        letter-spacing: normal;
       }
 
-      // Second Level
-      > ul > li > ul {
-        margin-bottom: 20px;
-      }
+      @include media(tablet) {
+        // Level 2
+        > ul > li > ul {
+          margin-bottom: 20px;
+        }
 
-      // Third Level & Below
-      li li li {
-        margin-left: $gutter-half;
+        // Level 3
+        li li li {
+          a:link, a:visited {
+            padding-left: $gutter-half * 2;
+          }
+        }
+
+        // Level 4
+        li li li li {
+          a:link, a:visited {
+            padding-left: $gutter-half * 4;
+          }
+        }
+
+        // Level 5
+        li li li li li {
+          a:link, a:visited {
+            padding-left: $gutter-half * 5;
+          }
+        }
+
+        // Level 6
+        li li li li li li {
+          a:link, a:visited {
+            padding-left: $gutter-half * 6;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Rather than emboldening the active element, we highlight it with a light grey background and add a five pixel left hand border in the active link colour. This makes the highlighting more obvious, and allows us to do away with the letter-spacing ‘hack’ which was trying to prevent items reflowing when they became bold.

Unfortunately because each item in the table of contents now needs to effectively act as a block of the same size, we can no longer rely on the nested nature of the lists. Instead we have to define the behaviour for each level individually. We’ve implemented indentation for the first six levels of navigation. In a real world situation this number of levels are unlikely to be exposed, but given we have to choose a number of levels to support, matching the h1…h6 elements makes some sense.

## Before
![screen shot 2017-03-01 at 14 07 14](https://cloud.githubusercontent.com/assets/121939/23463620/25b08a10-fe8a-11e6-9b15-81044099be18.png)

## After
![screen shot 2017-03-01 at 14 08 15](https://cloud.githubusercontent.com/assets/121939/23463630/2dc6b576-fe8a-11e6-850f-58a886798235.png)
