### PR TITLE
Support monospace headings

### DIFF
--- a/template/source/stylesheets/modules/_technical-documentation.scss
+++ b/template/source/stylesheets/modules/_technical-documentation.scss
@@ -170,6 +170,16 @@
     word-break: break-word;
   }
 
+  // Support monospace headings for e.g. listing API endpoints
+  h1, h2, h3, h4, h5, h6 {
+    code {
+      font-size: inherit;
+      color: $text-colour;
+      background: none;
+      padding: 0;
+    }
+  }
+
   .table-container {
     display: block;
     max-width: 100%;


### PR DESCRIPTION
The publishing docs use monospaced headings for listing the endpoints available in API docs. This changes `<code>` elements within headings so that they look more like the headings in terms of font size, colour and the lack of background.

Fixes #97 

## Before
![screen shot 2017-03-13 at 15 20 09](https://cloud.githubusercontent.com/assets/121939/23861006/96117d80-0800-11e7-999e-f9d35477e507.png)

## After
![screen shot 2017-03-13 at 15 19 44](https://cloud.githubusercontent.com/assets/121939/23861010/98b25f8c-0800-11e7-9e62-0a873c0c5b16.png)
