### PR TITLE
Remove extra padding from multi line code blocks (regression)

### DIFF
--- a/template/source/stylesheets/modules/_technical-documentation.scss
+++ b/template/source/stylesheets/modules/_technical-documentation.scss
@@ -143,6 +143,7 @@
   pre code {
     background: none;
     color: inherit;
+    padding: 0;
   }
 
   code {


### PR DESCRIPTION
This removes some extra padding which otherwise ends up ‘indenting’ the first line of a multi line code block by 3px.

This was previously done in d5518b7 but was accidentally reverted as part of 53ac7c7.

:man_facepalming: 