### PR TITLE
Don't do markdown emphasis inside words

### DIFF
--- a/template/config.rb
+++ b/template/config.rb
@@ -12,7 +12,8 @@ set :markdown,
       with_toc_data: true
     ),
     fenced_code_blocks: true,
-    tables: true
+    tables: true,
+    no_intra_emphasis: true
 
 # Per-page layout changes:
 #


### PR DESCRIPTION
This changes the behaviour for using_snake_case_in_a_word. By default, the markdown renderer will emphasise the words inside the snake cased words. In technical documentation this is almost never what we want, since a lot of programming terms use snake case to mean identifiers.

https://trello.com/c/jAA7b1pr