### PR TITLE
Configure GA tracking options

### DIFF
--- a/template/source/layouts/_analytics.erb
+++ b/template/source/layouts/_analytics.erb
@@ -5,6 +5,9 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'displayFeaturesTask', null);
+
   ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
   ga('send', 'pageview');
   </script>


### PR DESCRIPTION
This follows the configuration we use on GOV.UK to anonymise IP addresses and disable advert tracking: https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/google-analytics-universal-tracker.js#L13-L21