### PR TITLE
Correct configuration for GA

### DIFF
--- a/template/source/layouts/_analytics.erb
+++ b/template/source/layouts/_analytics.erb
@@ -5,10 +5,10 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+  ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
   ga('set', 'anonymizeIp', true);
   ga('set', 'displayFeaturesTask', null);
-
-  ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
+  ga('set', 'transport', 'beacon');
   ga('send', 'pageview');
   </script>
 <% end %>


### PR DESCRIPTION
Set commands should be added to the command queue after the create tracker command.

To avoid missing hits in GA when a document unloads, set the tracker to use the Navigator.sendBeacon() transport mechanism when available.  This will transmit hits to GA asynchronously when the User Agent has an opportunity to do so, without delaying the unload or affecting the performance of the next navigation.  GA will fallback to XMLHttpRequest or Image transport mechanisms when navigator.sendBeacon isn't supported by the user's browser.

See:
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon

https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms