### PR TITLE
Move nginx.conf into source

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -100,8 +100,8 @@ e.g. docs.larry-the-cat.service.gov.uk
       return unless @use_paas
 
       template 'optional/manifest.yml', 'manifest.yml'
-      copy_file 'optional/nginx.conf', 'nginx.conf'
-      gsub_file 'nginx.conf', '__CANONICAL_HOST__', @canonical_host
+      copy_file 'optional/nginx.conf', 'source/nginx.conf'
+      gsub_file 'source/nginx.conf', '__CANONICAL_HOST__', @canonical_host
       directory 'optional/script', 'script'
     end
 

--- a/optional/script/deploy
+++ b/optional/script/deploy
@@ -50,6 +50,5 @@ echo "OK!"
 
 bundle exec middleman build
 cp Staticfile.auth build
-cp nginx.conf build
 cf target -o govuk-service-manual -s integration
 cf push


### PR DESCRIPTION
In the gds-way repo we're deploying tech docs from Travis (not sure how common this is) our configuration to do that is in .[travis.yml](https://github.com/alphagov/gds-way/blob/master/.travis.yml) with no need to call a separate deploy script. In setting this up we missed the step to copy nginx configuration, it seems easier to have middleman copy over the file. This PR moves the file into source which makes middleman include it in the build folder.

A question for a separate PR could be if we should be recommending the .travis.yml configuration rather than including the deploy script?