### PR TITLE
Re-add the dividing lines between H1 sections.

### DIFF
--- a/template/source/stylesheets/modules/_technical-documentation.scss
+++ b/template/source/stylesheets/modules/_technical-documentation.scss
@@ -40,9 +40,11 @@
   h1 {
     @include bold-48;
     @include heading-offset($gutter * 2);
+    border-top: 5px solid $text-colour;
     
     &:first-of-type {
       @include heading-offset($gutter);
+      border-top: none;
     }
   }
 


### PR DESCRIPTION
These were removed in #95.

We (the PaaS team) have seen users getting confused by the one-page
layout in research. We therefore think that removing these dividing
lines is only going to exacerbate this.

Before:
![image](https://user-images.githubusercontent.com/5560/32899987-499a7ff4-cae4-11e7-9a3c-e01855883b0f.png)

After:
![image](https://user-images.githubusercontent.com/5560/32899924-240e56c0-cae4-11e7-8839-dc058cb5c431.png)
