### PR TITLE
Use non-flexbox layout for non-js layout

### DIFF
--- a/template/source/stylesheets/modules/_app-pane.scss
+++ b/template/source/stylesheets/modules/_app-pane.scss
@@ -49,7 +49,8 @@
       }
     }
 
-    .no-flexbox.no-flexboxtweener {
+    .no-flexbox.no-flexboxtweener,
+    .no-js {
       .app-pane__toc {
         float: left;
         width: $toc-width;


### PR DESCRIPTION
This causes the layout to fallback to the non-flexbox version when javascript is disabled.

We use Modernizr to sniff for Flexbox support because IE11 supports flexbox but does not support feature queries, and at the time this was done we believed that IE11 users would outnumber non-js users.

## Before

![screen shot 2017-11-20 at 16 02 09](https://user-images.githubusercontent.com/121939/33028033-9f034414-ce0c-11e7-975e-0e03a3216d0c.png)


## After

![screen shot 2017-11-20 at 16 04 19](https://user-images.githubusercontent.com/121939/33028041-a1de8158-ce0c-11e7-9f02-20122af97e5d.png)


Fixes #119 