### PR TITLE
Add markdown table to example

### DIFF
--- a/optional/source/documentation/index.md
+++ b/optional/source/documentation/index.md
@@ -6,6 +6,14 @@ Open `source/documentation/index.md` in your favourite text editor and start edi
 
 You can write content in [Markdown](https://daringfireball.net/projects/markdown/) using **all** of the _usual_ syntax that you're used to!
 
+This means you can use things like tables:
+
+Food | Kind | Tasty?
+--- | --- | ---
+Bananas | Fruit | Yes
+Aubergines | Vegetable | No
+Apricots | Fruit | Yes
+
 To change the title of the page or include additional files you'll need to edit `source/index.html.md.erb`.
 
 If you want slightly more control, you can always use <strong>HTML</strong>.


### PR DESCRIPTION
This adds a markdown table to the example page to illustrate how to generate a table.

![screen shot 2017-12-13 at 17 28 50](https://user-images.githubusercontent.com/233676/33953098-c96e2b98-e02b-11e7-9447-a0dca45e78b6.png)

Closes #138 & #139.