### PR TITLE
Improve instructions for local development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'middleman'
+
 group :development, :test do
   gem 'jasmine'
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,95 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    backports (3.8.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    concurrent-ruby (1.0.5)
+    contracts (0.13.0)
     diff-lcs (1.2.5)
+    dotenv (2.2.1)
+    erubis (2.7.0)
+    execjs (2.7.0)
+    fast_blank (1.0.0)
+    fastimage (2.1.0)
+    ffi (1.9.18)
+    haml (5.0.1)
+      temple (>= 0.8.0)
+      tilt
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    hashie (3.5.5)
+    i18n (0.7.0)
     jasmine (2.5.1)
       jasmine-core (>= 2.5.1, < 3.0.0)
       phantomjs
       rack (>= 1.2.1)
       rake
     jasmine-core (2.5.2)
+    kramdown (1.15.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    memoist (0.16.0)
+    middleman (4.2.1)
+      coffee-script (~> 2.2)
+      compass-import-once (= 1.0.5)
+      haml (>= 4.0.5)
+      kramdown (~> 1.2)
+      middleman-cli (= 4.2.1)
+      middleman-core (= 4.2.1)
+      sass (>= 3.4.0, < 4.0)
+    middleman-cli (4.2.1)
+      thor (>= 0.17.0, < 2.0)
+    middleman-core (4.2.1)
+      activesupport (>= 4.2, < 5.1)
+      addressable (~> 2.3)
+      backports (~> 3.6)
+      bundler (~> 1.1)
+      contracts (~> 0.13.0)
+      dotenv
+      erubis
+      execjs (~> 2.0)
+      fast_blank
+      fastimage (~> 2.0)
+      hamster (~> 3.0)
+      hashie (~> 3.4)
+      i18n (~> 0.7.0)
+      listen (~> 3.0.0)
+      memoist (~> 0.14)
+      padrino-helpers (~> 0.13.0)
+      parallel
+      rack (>= 1.4.5, < 3)
+      sass (>= 3.4)
+      servolux
+      tilt (~> 2.0)
+      uglifier (~> 3.0)
+    minitest (5.10.3)
+    padrino-helpers (0.13.3.4)
+      i18n (~> 0.6, >= 0.6.7)
+      padrino-support (= 0.13.3.4)
+      tilt (>= 1.4.1, < 3)
+    padrino-support (0.13.3.4)
+      activesupport (>= 3.1)
+    parallel (1.12.0)
     phantomjs (2.1.1.0)
+    public_suffix (3.0.1)
     rack (2.0.1)
     rake (12.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -24,14 +103,25 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    sass (3.4.25)
+    servolux (0.13.0)
+    temple (0.8.0)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    tilt (2.0.8)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
+    uglifier (3.2.0)
+      execjs (>= 0.3.0, < 3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jasmine
+  middleman
   rake
   rspec
 
 BUNDLED WITH
-   1.12.1
+   1.15.1

--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ If you make changes to the template you can create a test site with this command
 Make sure that you've committed your changes first, because Middleman works with Git.
 
 ```
-middleman init tmp/test-run -T file://$(pwd)
+bundle install
+bundle exec middleman init tmp/test-run -T file://$(pwd)
 cd tmp/test-run
-bundle exec middleman build
+bundle exec middleman server
 ```
+
+Your generated site should appear on <http://localhost:4567>.
 
 [mm]: https://middlemanapp.com/
 [mmt]: https://middlemanapp.com/advanced/project_templates/


### PR DESCRIPTION
Since this is a Middleman template, developers working on the template itself have to create a new site to test changes.

This adds middleman to the Gemfile (so all dependencies are installed) and updates the instructions.

This PR is best reviewed by trying out the new instructions and confirming a new static site is generated.