### PR TITLE
Put the “GitHub repo” link for projects consistently in brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is in active use by:
 
 In development:
 
-- GOV.UK Notify [GitHub repo](https://github.com/alphagov/notifications-tech-docs)
+- GOV.UK Notify ([GitHub repo](https://github.com/alphagov/notifications-tech-docs))
 
 ## Prerequisites
 


### PR DESCRIPTION
- The GOV.UK Notify project GitHub repo wasn’t in brackets and it looked weird compared to the others.