### PR TITLE
Use https for gem definitions

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -13,4 +13,4 @@ gem 'govuk_tech_docs'
 
 # Overrride middleman-search with our fork.
 # See: https://github.com/manastech/middleman-search/pull/24
-gem 'middleman-search', :git => "git://github.com/alphagov/middleman-search.git"
+gem 'middleman-search', git: 'https://github.com/alphagov/middleman-search'


### PR DESCRIPTION
We should be using `https` for gem locations, not `git`.