### PR TITLE
Deploy 2 instances when deploying to PaaS

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -71,7 +71,7 @@ module Middleman
       if option_set?('USE_PAAS')
         @use_paas = parse_boolean('USE_PAAS')
       else
-        @use_paas = yes?('Will you be deploying this on Government PaaS?')
+        @use_paas = yes?('Will you be deploying this on GOV.UK PaaS?')
       end
 
       return unless @use_paas

--- a/optional/manifest.yml.tt
+++ b/optional/manifest.yml.tt
@@ -2,5 +2,6 @@
 applications:
 - name: <%= @application_name %>
   memory: 64M
+  instances: 2
   path: ./build
   buildpack: staticfile_buildpack


### PR DESCRIPTION
A production app should always use more than 1 instance on the PaaS,
otherwise there will be the potential for downtime when changes to the
platform are being deployed.

Also fix the branding when asking about the PaaS.