### PR TITLE
Correct middleman-search gem name to match name specified in gemspec

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -13,4 +13,4 @@ gem 'govuk_tech_docs'
 
 # Overrride middleman-search with our fork.
 # See: https://github.com/manastech/middleman-search/pull/24
-gem 'middleman-search', git: 'https://github.com/alphagov/middleman-search'
+gem 'middleman-search-gds', git: 'https://github.com/alphagov/middleman-search'


### PR DESCRIPTION
https://github.com/alphagov/middleman-search/blob/master/middleman-search.gemspec#L7

<img width="820" alt="screen shot 2018-10-31 at 15 20 59" src="https://user-images.githubusercontent.com/159200/47798585-9c8d5480-dd20-11e8-85e9-4dfe58e0be81.png">
