### PR TITLE
Remove fork from template Gemfile

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -10,7 +10,3 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
 gem 'govuk_tech_docs'
-
-# Overrride middleman-search with our fork.
-# See: https://github.com/manastech/middleman-search/pull/24
-gem 'middleman-search', git: 'https://github.com/alphagov/middleman-search'


### PR DESCRIPTION
The latest version of tech-docs-gem now points to gds-middleman-search
directly.

See https://github.com/alphagov/tech-docs-template/pull/175