### PR TITLE
Fail build if there are dead internal links

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -10,3 +10,6 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
 gem 'govuk_tech_docs'
+
+# Include linter to check for dead internal links
+gem 'html-proofer'

--- a/template/config.rb
+++ b/template/config.rb
@@ -1,3 +1,16 @@
 require 'govuk_tech_docs'
+require 'html-proofer'
 
 GovukTechDocs.configure(self)
+
+after_build do |builder|
+  begin
+    HTMLProofer.check_directory(config[:build_dir],
+      { :assume_extension => true,
+        :disable_external => true,
+        :allow_hash_href => true,
+        :url_swap => { config[:tech_docs][:host] => "" } }).run
+  rescue RuntimeError => e
+    abort e.to_s
+  end
+end


### PR DESCRIPTION
Using html-proofer. Will apply to new projects only - existing users of the template would need to apply this change manually.

Resolves #186