### PR TITLE
Add support for 64-bit Windows to gem dependencies

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,10 +3,10 @@
 source 'https://rubygems.org'
 
 # For faster file watcher updates on Windows:
-gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
+gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw, :x64_mingw]
 
 # Windows does not come with time zone data
-gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
+gem 'tzinfo-data', platforms: [:mswin, :mingw, :x64_mingw, :jruby]
 
 # Include the tech docs gem
 gem 'govuk_tech_docs'


### PR DESCRIPTION
This change enables the generation of sites using tech-docs-template on 64-bit Windows