### PR TITLE
Replace readme content with links to TDT documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,40 +14,6 @@ You’re welcome to use the template even if your service isn’t considered par
 
 👉 To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation][tdt-docs].
 
-## Get started
-
-To use the Tech Docs Template, see the [Tech Docs Template documentation on getting started](https://tdt-documentation.london.cloudapps.digital/create_project/get_started/#get-started).
-
-## Create a new documentation project
-
-To create a new project using the Tech Docs Template, see the [Tech Docs Template documentation on creating a new documentation project](https://tdt-documentation.london.cloudapps.digital/create_project/create_new_project/#create-a-new-documentation-project).
-
-## Preview your website locally
-
-To preview your new website locally, see the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
-
-## Configure your website
-
-To configure your documentation site, see the [Tech Docs Template documentation on configuring your documentation site](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#configure-your-documentation-site).
-
-To configure individual documentation site pages, see the [Tech Docs Template documentation on configuring page settings](https://tdt-documentation.london.cloudapps.digital/configure_project/frontmatter/#configure-page-settings).
-
-## Write your content
-
-For more information on writing and editing your content, see the [Tech Docs Template documentation on writing your documentation](https://tdt-documentation.london.cloudapps.digital/write_docs/#write-your-documentation).
-
-## Publishing
-
-For more information on publishing your website, see the [Tech Docs Template documentation on publishing your documentation project](https://tdt-documentation.london.cloudapps.digital/publish_project/#publish-your-documentation-project).
-
-## Troubleshooting
-
-Run `bundle update` to make sure you're using the most recent Ruby gem versions.
-
-Run `bundle exec middleman build --verbose` to get detailed error messages to help with finding the problem.
-
-For more information, see the [Tech Docs Template documentation on maintaining your documentation project](https://tdt-documentation.london.cloudapps.digital/maintain_project/#maintain-your-documentation-project).
-
 ## Contribute
 
 👉 See the [CONTRIBUTE.md file in the tech-docs-gem repository][contribute].

--- a/README.md
+++ b/README.md
@@ -14,90 +14,39 @@ You’re welcome to use the template even if your service isn’t considered par
 
 👉 To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation][tdt-docs].
 
-## Before you start
-
-To use the Tech Docs Template you need:
-
-- [Ruby][install-ruby]
-- [Middleman][install-middleman]
-
 ## Get started
 
-To create a new project using the Tech Docs Template, run:
+To use the Tech Docs Template, see the [Tech Docs Template documentation on getting started](https://tdt-documentation.london.cloudapps.digital/create_project/get_started/#get-started).
 
-```sh
-middleman init PROJECT_NAME -T alphagov/tech-docs-template
-```
+## Create a new documentation project
 
-where `PROJECT_NAME` is the name of your new project.
-
-This command creates a minimal functional website using the Tech Docs Template.
+To create a new project using the Tech Docs Template, see the [Tech Docs Template documentation on creating a new documentation project](https://tdt-documentation.london.cloudapps.digital/create_project/create_new_project/#create-a-new-documentation-project).
 
 ## Preview your website locally
 
-To preview your new website locally, navigate to your project folder and run:
-
-```sh
-bundle exec middleman server
-```
-
-👉 See the generated website on `http://localhost:4567` in your browser. Any content changes you make to your website will be updated in real time.
-
-To shut down the Middleman instance running on your machine, use `ctrl+C`.
-
-If you make changes to the `config/tech-docs.yml` configuration file, you need to restart Middleman to see the changes.
+To preview your new website locally, see the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
 ## Configure your website
 
-The `middleman init` command creates a minimal website with basic configuration.
+To configure your documentation site, see the [Tech Docs Template documentation on configuring your documentation site](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#configure-your-documentation-site).
 
-You can change your website's configuration by editing the `config/tech-docs.yml` file.
+To configure individual documentation site pages, see the [Tech Docs Template documentation on configuring page settings](https://tdt-documentation.london.cloudapps.digital/configure_project/frontmatter/#configure-page-settings).
 
-👉 See what [configuration options][config] are available.
+## Write your content
 
-You can set page-specific options by editing the page's frontmatter.
-
-👉 See how [frontmatter configuration options][frontmatter] are available.
-
-## Adding content
-
-You can add content by editing the `index.html.md.erb` file. These files support content in:
-
-- Markdown
-- HTML
-- Ruby
-
-👉 For example, you can use Markdown and HTML to [generate different content types][example-content] and [Ruby partials to manage content][partials].
-
-Any file in the `source` folder ending in `.html.md.erb` produces a separate page for your website.
-
-👉 Learn more about [producing more complex page structures][multipage] for your website.
-
-![Screenshot of Example Documentation](screenshots/multipage-example.png)
+For more information on writing and editing your content, see the [Tech Docs Template documentation on writing your documentation](https://tdt-documentation.london.cloudapps.digital/write_docs/#write-your-documentation).
 
 ## Publishing
 
-To publish your website, you need to:
-
-- build the HTML pages
-- host your website
-- decide how to push changes to your website
-
-To build the HTML pages from content in your `source` folder, run:
-
-```
-bundle exec middleman build
-```
-
-Every time you run this command, the `build` folder gets generated from scratch. This means any changes to the `build` folder that are not part of the build command will get overwritten.
-
-There are many options for hosting and pushing changes to your website, so it's worth considering user needs and constraints before making a choice.
+For more information on publishing your website, see the [Tech Docs Template documentation on publishing your documentation project](https://tdt-documentation.london.cloudapps.digital/publish_project/#publish-your-documentation-project).
 
 ## Troubleshooting
 
 Run `bundle update` to make sure you're using the most recent Ruby gem versions.
 
 Run `bundle exec middleman build --verbose` to get detailed error messages to help with finding the problem.
+
+For more information, see the [Tech Docs Template documentation on maintaining your documentation project](https://tdt-documentation.london.cloudapps.digital/maintain_project/#maintain-your-documentation-project).
 
 ## Contribute
 


### PR DESCRIPTION
Replace readme content with links to TDT documentation. This means that this readme stays aligned with the TDT documentation.