### PR TITLE
Remove duplicate header link

### DIFF
--- a/optional/config/tech-docs.yml.tt
+++ b/optional/config/tech-docs.yml.tt
@@ -9,7 +9,7 @@ phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
-  About: https://www.larry-the-cat.service.gov.uk
+  About: https://www.larry-the-cat.service.gov.uk/about
   Get Started: https://www.larry-the-cat.service.gov.uk/get-started
   Documentation: /
   Support: https://www.larry-the-cat.service.gov.uk/support


### PR DESCRIPTION
This updates the template for the `tech-docs.yml` file, to ensure that a base Tech Docs Template instance does not have 2 duplicate links to the same place (the `service_link` link and the `about` link) - which was causing accessibility issues.