### PR TITLE
Add support for middleman using Windows 64-bit 'mingw32' platform

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,10 +3,10 @@
 source 'https://rubygems.org'
 
 # For faster file watcher updates on Windows:
-gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
+gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw, :x64_mingw]
 
 # Windows does not come with time zone data
-gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
+gem 'tzinfo-data', platforms: [:mswin, :mingw, :x64_mingw, :jruby]
 
 # Include the tech docs gem
 gem 'govuk_tech_docs'


### PR DESCRIPTION
We want users who have installed Ruby using RubyInstaller x64 (or a 64-bit mingw installation) to be able to use `middleman init -T alphagov/tech-docs-template`; currently they will get warnings saying:

> The dependency ... will be unused by any of the platforms Bundler is installing for. Bundler is installing for x64-mingw32 but the dependency is only for x86-mswin32, x86-mingw32.

because we only specify `mingw` in the [template Gemfile](https://github.com/alphagov/tech-docs-template/blob/master/template/Gemfile). Without `wdm` the template Thorfile will fail to execute with the error

> Unable to find a spec satisfying wdm (~> 0.1.0) in the set.

This commit adds `x64_mingw` to the list of platforms which require `wdm` and `tzinfo-data`, which fixes things.