### PR TITLE
Fix failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: ruby
 rvm:
  - 2.6.6
 before_install:
-  - nvm install 10
+  - nvm install 14
 script:
   - ./create-test-site.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
  - 2.6.6
+before_install:
+  - nvm install 10
 script:
   - ./create-test-site.sh


### PR DESCRIPTION
Travis CI is currently defaulting to using Node.js v8.x.x because the Travis config file does not specify to use Node at all.

However a version of Node greater than 10 is needed for this repo, because the tech-docs-gem uses it, so Travis builds are failing across the board.

This PR uses [nvm](https://github.com/nvm-sh/nvm) to make sure that the version of Node used for tests is the latest version of the current long term support (LTS) series.