### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/optional/config/tech-docs.yml.tt
+++ b/optional/config/tech-docs.yml.tt
@@ -36,3 +36,4 @@ prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/YOUR_REPO
+github_branch: main

--- a/optional/script/deploy
+++ b/optional/script/deploy
@@ -18,13 +18,13 @@ if [[ ! -f Staticfile.auth ]]; then
 fi
 echo "OK!"
 
-# Check that we're on master, or there's an environment variable set to override
+# Check that we're on main, or there's an environment variable set to override
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "Checking branch..."
-if [[ $BRANCH != "master" ]] && [[ $I_REALISE_I_AM_NOT_ON_MASTER != "y" ]]; then
-  error "Current branch is not master, cowardly refusing to deploy"
-  error "To force override, run this again with I_REALISE_I_AM_NOT_ON_MASTER=y"
+if [[ $BRANCH != "main" ]] && [[ $I_REALISE_I_AM_NOT_ON_MAIN != "y" ]]; then
+  error "Current branch is not main, cowardly refusing to deploy"
+  error "To force override, run this again with I_REALISE_I_AM_NOT_ON_MAIN=y"
   exit 1
 fi
 echo "OK!"


### PR DESCRIPTION
We've renamed the default branch to main, following best practice on GitHub [[1]], and we want and expect that users will do the same. This is especially the case for new repositories on GitHub, which will have the name 'main' instead of 'master'.

This PR updates the example deploy script to match.

We also add the new default branch name to the config template. This is because in the [tech-docs-gem](github.com/alphagov/tech-docs-gem) we assume the default branch is named 'master', and changing that would be a breaking change. By changing it here we can immediately reach new users of the tech docs template (without affecting our ability to make the breaking change), and it also keeps the example deploy script and the build output consistent.

[1]: https://github.com/github/renaming