### PR TITLE
Fix links to Ruby/Middleman docs

### DIFF
--- a/optional/README.md
+++ b/optional/README.md
@@ -79,7 +79,7 @@ The documentation is [© Crown copyright][copyright] and available under the ter
 [multipage]: https://tdt-documentation.london.cloudapps.digital/multipage.html#build-a-multipage-site
 [example-content]: https://tdt-documentation.london.cloudapps.digital/content.html#content-examples
 [partials]: https://tdt-documentation.london.cloudapps.digital/single_page.html#add-partial-lines
-[install-ruby]: https://tdt-documentation.london.cloudapps.digital/install_macs.html#install-ruby
-[install-middleman]: https://tdt-documentation.london.cloudapps.digital/install_macs.html#install-middleman
+[install-ruby]: https://tdt-documentation.london.cloudapps.digital/create_project/get_started/#install-ruby
+[install-middleman]: https://tdt-documentation.london.cloudapps.digital/create_project/get_started/#install-middleman
 [gem]: https://github.com/alphagov/tech-docs-gem
 [template]: https://github.com/alphagov/tech-docs-template


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->
Links in the template README to Ruby and Middleman installations.

(There's likely scope to identifying dead links here, somehow, but that's not part of this PR.)

## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->
As a developer not familiar with Ruby/Middleman, I need working links to the installation instructions

