### PR TITLE
- make repo use jobs as a pipeline

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,9 +1,6 @@
 name: 'Dependency Review'
 on:
-  pull_request:
-    branches: [ "main" ]
-  push:
-    branches: [ "main" ]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,0 +1,14 @@
+name: pipeline
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+# needs a linting step
+jobs:
+  dependency-review:
+    uses: ./.github/workflows/dependency-review.yaml
+
+  test:
+    needs: dependency-review
+    uses: ./.github/workflows/test.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,6 @@
 name: Test
-
 on:
-  pull_request:
-    branches: [ "main" ]
-  push:
-    branches: [ "main" ]
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
## Proposed changes

### What changed

GitHub actions have been set to run on workflow call rather than push
single CI/CD job set up to use the steps as a pipeline

## Related issue or tracking reference

no issue, just a minor tech debt update



## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [ ] GitHub actions all pass
- [ ] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed
